### PR TITLE
section 級 backlinks(被引用於依段落分組)

### DIFF
--- a/docs/superpowers/plans/2026-06-13-section-backlinks.md
+++ b/docs/superpowers/plans/2026-06-13-section-backlinks.md
@@ -1,0 +1,401 @@
+# Section-Level Backlinks Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Group each post's "🔗 被引用於" panel by the section that was referenced (`[[slug#heading]]`), with a "整篇文章" group for whole-post links.
+
+**Architecture:** A pure `extractLinks` captures each wikilink's `{slug, anchor}`. `getBacklinks` returns `{post, anchor}` refs. A pure `groupBySection` buckets refs by the target post's headings (from Astro's `render()` `headings`), ordered by heading order with "整篇文章" last. `PostLayout` renders the grouped panel.
+
+**Tech Stack:** Astro 6, `github-slugger` (anchors), Node 22 `node:test`.
+
+**Spec:** `docs/superpowers/specs/2026-06-13-section-backlinks-design.md`
+
+---
+
+## Current state (on master, post PR #8)
+
+- `src/lib/wiki-link.mjs` exports `wikiLinkRegex`, `slugifyHeading`, `parseTarget`, `splitWikiLinks(value, ctx)`, `extractTargets(body)` (returns `string[]` of base slugs, sections stripped, same-page ignored).
+- `src/lib/backlinks.ts`: `getBacklinks(targetSlug)` returns `CollectionEntry<'blog'>[]` (uses `extractTargets`).
+- `src/layouts/PostLayout.astro`: computes `const backlinks = await getBacklinks(post.id)` and renders a FLAT `<ul>` aside (lines 66–75); `Props` is `{ post }`.
+- `src/pages/blog/[slug].astro`: `const { Content } = await render(post)` → `<PostLayout post={post}><Content/></PostLayout>`.
+- `test/wiki-link.test.mjs`: 16 tests; `package.json` `test` = `node --test test/**/*.mjs` (auto-globs new `test/*.mjs`).
+
+---
+
+## File Structure
+
+- `src/lib/wiki-link.mjs` (Modify) — add `extractLinks`; refactor `extractTargets` to use it.
+- `src/lib/wiki-link.d.mts` (Modify) — declare `extractLinks`.
+- `src/lib/group-backlinks.mjs` (Create) — pure `groupBySection(backlinks, headings)`. Separate from `backlinks.ts` so it imports no `astro:content` and is unit-testable under `node:test`.
+- `src/lib/group-backlinks.d.mts` (Create) — declarations.
+- `src/lib/backlinks.ts` (Modify) — `getBacklinks` returns `{post, anchor}[]`.
+- `src/pages/blog/[slug].astro` (Modify) — pass `headings` to `PostLayout`.
+- `src/layouts/PostLayout.astro` (Modify) — group + render the panel.
+- `test/wiki-link.test.mjs` (Modify) — `extractLinks` tests.
+- `test/group-backlinks.test.mjs` (Create) — `groupBySection` tests.
+
+---
+
+### Task 1: `extractLinks` (and refactor `extractTargets`)
+
+**Files:**
+- Modify: `src/lib/wiki-link.mjs`
+- Modify: `src/lib/wiki-link.d.mts`
+- Modify: `test/wiki-link.test.mjs`
+
+- [ ] **Step 1: Add failing tests**
+
+In `test/wiki-link.test.mjs`, change the import line to add `extractLinks`:
+```js
+import { splitWikiLinks, extractTargets, slugifyHeading, parseTarget, extractLinks } from '../src/lib/wiki-link.mjs';
+```
+Then append these tests at the end of the file:
+```js
+test('extractLinks returns slug + anchor, ignoring same-page links', () => {
+  assert.deepEqual(
+    extractLinks('[[btl-5]] [[btl-5#障礙一：看不到自己]] [[#反思]] [[btl-6|z]]'),
+    [
+      { slug: 'btl-5', anchor: null },
+      { slug: 'btl-5', anchor: '障礙一看不到自己' },
+      { slug: 'btl-6', anchor: null },
+    ]
+  );
+});
+
+test('extractLinks returns an empty array for an empty body', () => {
+  assert.deepEqual(extractLinks(''), []);
+});
+```
+
+- [ ] **Step 2: Run tests, verify failure**
+
+Run: `npm test`
+Expected: FAIL — `extractLinks` is not exported yet.
+
+- [ ] **Step 3: Implement `extractLinks` and refactor `extractTargets`**
+
+In `src/lib/wiki-link.mjs`, REPLACE the current `extractTargets` function (the block starting `// Collect referenced base slugs` through its closing `}`) with:
+```js
+// Collect referenced links as { slug, anchor }. anchor = slugified section, or
+// null for a whole-post link. Same-page links (empty slug) are ignored.
+export function extractLinks(body) {
+  const re = wikiLinkRegex();
+  const links = [];
+  let m;
+  while ((m = re.exec(body ?? '')) !== null) {
+    const { slug, section } = parseTarget(m[1].trim());
+    if (slug === '') continue;
+    const sectionText = section !== undefined ? section.trim() : '';
+    links.push({ slug, anchor: sectionText ? slugifyHeading(sectionText) : null });
+  }
+  return links;
+}
+
+// Collect referenced base slugs (section stripped; same-page links ignored).
+export function extractTargets(body) {
+  return extractLinks(body).map((l) => l.slug);
+}
+```
+
+- [ ] **Step 4: Declare `extractLinks` in `src/lib/wiki-link.d.mts`**
+
+Add this line after the `extractTargets` declaration:
+```ts
+export function extractLinks(body: string): { slug: string; anchor: string | null }[];
+```
+
+- [ ] **Step 5: Run tests, verify pass**
+
+Run: `npm test`
+Expected: PASS — all tests pass (18 now). The existing `extractTargets` tests still pass (behavior unchanged: `extractLinks(...).map(slug)` yields the same array, including duplicates).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/wiki-link.mjs src/lib/wiki-link.d.mts test/wiki-link.test.mjs
+git commit -m "feat: extractLinks (slug + anchor) for section backlinks"
+```
+
+---
+
+### Task 2: pure `groupBySection`
+
+**Files:**
+- Create: `src/lib/group-backlinks.mjs`
+- Create: `src/lib/group-backlinks.d.mts`
+- Create: `test/group-backlinks.test.mjs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `test/group-backlinks.test.mjs`:
+```js
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { groupBySection } from '../src/lib/group-backlinks.mjs';
+
+const post = (id, title) => ({ id, data: { title } });
+const headings = [
+  { slug: '障礙一看不到自己', text: '障礙一：看不到自己' },
+  { slug: '反思', text: '反思' },
+];
+
+test('groups by section in heading order, 整篇文章 last', () => {
+  const backlinks = [
+    { post: post('btl-6', '用日記看見自己'), anchor: '障礙一看不到自己' },
+    { post: post('other', '某篇'), anchor: null },
+    { post: post('btl-7', '反思那篇'), anchor: '反思' },
+  ];
+  assert.deepEqual(groupBySection(backlinks, headings), [
+    { label: '障礙一：看不到自己', sources: [post('btl-6', '用日記看見自己')] },
+    { label: '反思', sources: [post('btl-7', '反思那篇')] },
+    { label: '整篇文章', sources: [post('other', '某篇')] },
+  ]);
+});
+
+test('stale anchor (no matching heading) folds into 整篇文章', () => {
+  const backlinks = [{ post: post('x', 'X'), anchor: '已刪除的段' }];
+  assert.deepEqual(groupBySection(backlinks, headings), [
+    { label: '整篇文章', sources: [post('x', 'X')] },
+  ]);
+});
+
+test('returns an empty array when there are no backlinks', () => {
+  assert.deepEqual(groupBySection([], headings), []);
+});
+
+test('handles missing headings (everything folds into 整篇文章)', () => {
+  const backlinks = [{ post: post('a', 'A'), anchor: '反思' }];
+  assert.deepEqual(groupBySection(backlinks, undefined), [
+    { label: '整篇文章', sources: [post('a', 'A')] },
+  ]);
+});
+```
+
+- [ ] **Step 2: Run tests, verify failure**
+
+Run: `npm test`
+Expected: FAIL — `../src/lib/group-backlinks.mjs` does not exist.
+
+- [ ] **Step 3: Implement `src/lib/group-backlinks.mjs`**
+
+Create `src/lib/group-backlinks.mjs`:
+```js
+// Pure grouping for the "被引用於" panel. No I/O — unit-testable under node:test.
+// backlinks: Array<{ post, anchor: string|null }>  (post has .id and .data.title)
+// headings:  Array<{ slug, text }>                  (the target post's own headings)
+// Returns ordered groups: sections that have sources in heading order, then a
+// single "整篇文章" group last. Whole-post links (anchor null) and anchors that
+// match no heading fold into "整篇文章".
+const WHOLE_POST_LABEL = '整篇文章';
+
+export function groupBySection(backlinks, headings) {
+  const heads = headings ?? [];
+  const textBySlug = new Map(heads.map((h) => [h.slug, h.text]));
+  const sectionSources = new Map(); // anchor -> post[]
+  const wholePost = [];
+  for (const { post, anchor } of backlinks ?? []) {
+    if (anchor && textBySlug.has(anchor)) {
+      if (!sectionSources.has(anchor)) sectionSources.set(anchor, []);
+      sectionSources.get(anchor).push(post);
+    } else {
+      wholePost.push(post);
+    }
+  }
+  const groups = [];
+  for (const h of heads) {
+    const sources = sectionSources.get(h.slug);
+    if (sources && sources.length) groups.push({ label: h.text, sources });
+  }
+  if (wholePost.length) groups.push({ label: WHOLE_POST_LABEL, sources: wholePost });
+  return groups;
+}
+```
+
+- [ ] **Step 4: Declare types in `src/lib/group-backlinks.d.mts`**
+
+Create `src/lib/group-backlinks.d.mts`:
+```ts
+import type { CollectionEntry } from 'astro:content';
+
+export interface BacklinkRef {
+  post: CollectionEntry<'blog'>;
+  anchor: string | null;
+}
+
+export interface BacklinkGroup {
+  label: string;
+  sources: CollectionEntry<'blog'>[];
+}
+
+export function groupBySection(
+  backlinks: BacklinkRef[],
+  headings: { slug: string; text: string }[] | undefined
+): BacklinkGroup[];
+```
+
+- [ ] **Step 5: Run tests, verify pass**
+
+Run: `npm test`
+Expected: PASS — all tests pass (22 now: 18 + 4).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/group-backlinks.mjs src/lib/group-backlinks.d.mts test/group-backlinks.test.mjs
+git commit -m "feat: pure groupBySection for backlink grouping"
+```
+
+---
+
+### Task 3: wire `getBacklinks` + `PostLayout` + `[slug].astro`
+
+**Files:**
+- Modify: `src/lib/backlinks.ts`
+- Modify: `src/pages/blog/[slug].astro`
+- Modify: `src/layouts/PostLayout.astro`
+
+- [ ] **Step 1: `getBacklinks` returns `{post, anchor}[]`**
+
+Replace the ENTIRE contents of `src/lib/backlinks.ts` with:
+```ts
+import { getCollection } from 'astro:content';
+import type { CollectionEntry } from 'astro:content';
+import { extractLinks } from './wiki-link.mjs';
+
+export interface BacklinkRef {
+  post: CollectionEntry<'blog'>;
+  anchor: string | null;
+}
+
+// Backlinks to targetSlug as { post, anchor } (anchor = section slug, or null
+// for a whole-post link), deduped per (post, anchor), newest post first.
+export async function getBacklinks(targetSlug: string): Promise<BacklinkRef[]> {
+  const posts = (await getCollection('blog'))
+    .filter((p) => p.id !== targetSlug)
+    .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
+  const refs: BacklinkRef[] = [];
+  const seen = new Set<string>();
+  for (const post of posts) {
+    for (const { slug, anchor } of extractLinks(post.body ?? '')) {
+      if (slug !== targetSlug) continue;
+      const key = `${post.id}#${anchor ?? ''}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      refs.push({ post, anchor });
+    }
+  }
+  return refs;
+}
+```
+
+- [ ] **Step 2: Pass `headings` from `[slug].astro`**
+
+Replace the ENTIRE contents of `src/pages/blog/[slug].astro` with:
+```astro
+---
+import { getCollection, render } from 'astro:content';
+import PostLayout from '../../layouts/PostLayout.astro';
+
+export async function getStaticPaths() {
+  const posts = await getCollection('blog');
+  return posts.map((post) => ({
+    params: { slug: post.id },
+    props: { post },
+  }));
+}
+
+const { post } = Astro.props;
+const { Content, headings } = await render(post);
+---
+<PostLayout post={post} headings={headings}>
+  <Content />
+</PostLayout>
+```
+
+- [ ] **Step 3: Group + render in `PostLayout.astro`**
+
+In `src/layouts/PostLayout.astro`:
+
+(a) Add imports after the `getBacklinks` import (line 7):
+```astro
+import { groupBySection } from '../lib/group-backlinks.mjs';
+import type { MarkdownHeading } from 'astro';
+```
+
+(b) Replace the `Props` interface and props destructure (lines 9–10):
+```astro
+interface Props { post: CollectionEntry<'blog'>; headings?: MarkdownHeading[]; }
+const { post, headings = [] } = Astro.props;
+```
+
+(c) Replace the backlinks computation (line 24, `const backlinks = await getBacklinks(post.id);`) with:
+```astro
+const backlinkGroups = groupBySection(await getBacklinks(post.id), headings);
+```
+
+(d) Replace the backlinks aside block (lines 66–75, the `{backlinks.length > 0 && ( ... )}` block) with:
+```astro
+    {backlinkGroups.length > 0 && (
+      <aside class="mt-12 pt-6 border-t border-line text-sm">
+        <p class="font-bold mb-2">🔗 被引用於</p>
+        {backlinkGroups.map((g) => (
+          <div class="mb-3">
+            <p class="text-muted text-xs mb-1">{g.label}</p>
+            <ul class="list-none p-0 m-0 space-y-1">
+              {g.sources.map((s) => (
+                <li><a href={`/blog/${s.id}/`} class="text-accent hover:underline">{s.data.title}</a></li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </aside>
+    )}
+```
+
+- [ ] **Step 4: Build and verify the grouped panel end-to-end**
+
+Run: `npm run build`
+Expected: exit 0, no `[wiki-link]` warnings.
+
+btl-6 already links `[[btl-5#障礙一：看不到自己|…]]`, so btl-5's panel should now group btl-6 under that section. Verify (PowerShell):
+```powershell
+$c = Get-Content dist/blog/btl-5/index.html -Raw
+"section label present:"; $c -match '障礙一：看不到自己'
+"grouped btl-6 under a section (label <p> then btl-6 link):"; $c -match '被引用於[\s\S]*障礙一：看不到自己[\s\S]{0,200}href="/blog/btl-6/"'
+"backlinks panel still present:"; $c -match '被引用於'
+```
+Expected: all `True`.
+
+Also confirm a post with no backlinks still omits the panel:
+```powershell
+(Select-String -Path dist/blog/btl-3/index.html -Pattern '被引用於').Matches.Count
+```
+Expected: `0`.
+
+- [ ] **Step 5: Run unit tests**
+
+Run: `npm test`
+Expected: PASS (22).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/backlinks.ts src/pages/blog/[slug].astro src/layouts/PostLayout.astro
+git commit -m "feat: group backlinks by referenced section in PostLayout"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- `extractLinks` returns `{slug, anchor}`, same-page ignored; `extractTargets` refactored to use it → Task 1. ✅
+- `getBacklinks` returns `{post, anchor}[]`, deduped per (post,anchor), newest first → Task 3 Step 1. ✅
+- `groupBySection(backlinks, headings)`: section groups in heading order, 整篇文章 last, stale/null anchors fold into 整篇 → Task 2. ✅
+- `[slug].astro` passes `headings` from `render()`; `PostLayout` renders grouped panel, only when non-empty → Task 3 Steps 2–3. ✅
+- Blog-only, same-page not counted, schema untouched → no schema/guide files touched. ✅
+- Verification uses existing btl-6→btl-5#障礙一 link → Task 3 Step 4. ✅
+
+**Placeholder scan:** none — all steps contain complete code/commands.
+
+**Type/name consistency:** `extractLinks(body) → {slug, anchor}[]` used by `getBacklinks`; `BacklinkRef {post, anchor}` consistent between `backlinks.ts` and `group-backlinks.d.mts`; `groupBySection(backlinks, headings) → {label, sources}[]` consumed by `PostLayout` (`g.label`, `g.sources`, `s.id`, `s.data.title`). `headings` typed as `MarkdownHeading[]` (has `slug`/`text`) and `groupBySection` only reads `slug`/`text`. Anchors from `extractLinks` (github-slugger) match `headings[].slug` (github-slugger). Consistent.

--- a/docs/superpowers/specs/2026-06-13-section-backlinks-design.md
+++ b/docs/superpowers/specs/2026-06-13-section-backlinks-design.md
@@ -1,0 +1,78 @@
+# Section 級 backlinks 設計(底部分組)
+
+- 日期:2026-06-13
+- 範圍:把每篇文章底部的「🔗 被引用於」從「文章層級的扁平清單」升級成「依**被引用的 section**分組」,讓 section 真正像可被引用的卡片。
+- 站台:Astro(master 上線中)
+- **相依**:本功能**疊在 PR #8(wikilink section 連結)之上** —— 需要 `src/lib/wiki-link.mjs` 的 `parseTarget` 與 `slugifyHeading`。實作分支須在 PR #8 併入 master 後再從更新後的 master 切出。
+
+## 背景
+
+目前 backlinks 是**文章層級**:`extractTargets` 把 `[[slug#section]]` 的 `#section` 砍掉,`getBacklinks` 只知道「哪篇引用了這篇」,`PostLayout` 底部顯示一個扁平的來源清單。section 連結(PR #8)已經能「指到某段」,但被指的那段不知道誰引用它 —— 單向。本功能補上 section 層級的「被引用」資訊,維持單一底部面板(不做 inline)。
+
+## 已確認決策
+
+- **顯示位置 = 底部面板,依 section 分組**(B 方案;不做標題下 inline 的 A 方案)。
+- **失效錨點**(來源指向的 section 對不到本篇現有標題)→ 收進「**整篇文章**」群組。
+- 整篇連結(`[[slug]]`,無 section)→ 同樣收進「整篇文章」群組。
+- 群組順序:有對到標題的群組**照文章標題出現順序**;「整篇文章」群組排**最後**。
+- 仍只作用於 blog;同頁 `[[#x]]` 不計入 backlinks;schema 不動。
+
+## 設計內容
+
+### 1. `src/lib/wiki-link.mjs`
+
+- 新增 `extractLinks(body)` → `Array<{ slug, anchor }>`:逐個 wikilink,`parseTarget` 後,若 `slug` 非空則 push `{ slug, anchor: section ? slugifyHeading(section) : null }`。同頁(slug 空)略過。
+- `extractTargets(body)` 改寫為 `extractLinks(body).map((l) => l.slug)`(DRY;對外行為與現狀一致,backlinks 以外的呼叫端不受影響)。
+- `wiki-link.d.mts` 增補 `extractLinks` 宣告與 `{ slug: string; anchor: string | null }` 形狀。
+
+### 2. `src/lib/backlinks.ts`
+
+- `getBacklinks(targetSlug)` 回傳型別改為 `Promise<Array<{ post: CollectionEntry<'blog'>; anchor: string | null }>>`:
+  - 掃所有其他文章,`extractLinks(p.body ?? '')`,挑出 `slug === targetSlug` 的連結;每個 `{ post, anchor }` 一筆,**同 (post, anchor) 去重**。
+  - 依 `post.data.date` 由新到舊排序。
+- 新增純函式 `groupBySection(backlinks, headings)`:
+  - 參數:`backlinks: Array<{ post; anchor: string|null }>`、`headings: Array<{ slug: string; text: string }>`(Astro `render()` 的 headings,只取 `slug`/`text`)。
+  - 建 `anchor → headingText` 對照(來自 headings)。
+  - 分組規則:`anchor` 有對到某 heading slug → 歸到該 heading(label = heading text);`anchor` 為 null 或對不到任何 heading → 歸到 `整篇文章`。
+  - 回傳 `Array<{ label: string; sources: CollectionEntry<'blog'>[] }>`,**有對到標題的群組照 headings 出現順序、`整篇文章` 墊最後**;群組內 sources 維持日期排序、去重。
+  - 空輸入回傳 `[]`。
+
+### 3. 接線與顯示
+
+- `src/pages/blog/[slug].astro`:改成 `const { Content, headings } = await render(post);`,並 `<PostLayout post={post} headings={headings}>`。
+- `src/layouts/PostLayout.astro`:
+  - 介面新增 `headings`(`MarkdownHeading[]`,即 `{ depth; slug; text }[]`,預設 `[]`)。
+  - `const groups = groupBySection(await getBacklinks(post.id), headings);`
+  - 把現有扁平 backlinks 區塊改為分組渲染(**`groups.length > 0` 才顯示**):
+    ```
+    🔗 被引用於
+      〈section heading〉
+        · 〈來源文章〉
+      整篇文章
+        · 〈來源文章〉
+    ```
+  - 沿用現有 aside 樣式(`mt-12 pt-6 border-t border-line text-sm`);section label 用 `text-muted text-xs`,來源用 `text-accent hover:underline`。
+
+### 4. 不變 / 範圍
+
+- 只 blog;同頁連結不計;不做 A 方案 inline;不動 schema。
+- `extractTargets` 對外語義不變(只是改用 `extractLinks` 實作)。
+
+## 風險 / 注意
+
+- **anchor 比對**:來源寫的 section 文字經 `slugifyHeading` 後,要對得上 Astro `headings[].slug`(兩者都是 github-slugger 產物 → 一致;PR #8 已驗證)。
+- **`render()` 的 headings 形狀**:Astro 提供 `{ depth, slug, text }`;`groupBySection` 只依賴 `slug`/`text`,對 depth 不敏感。
+- **失效錨點**收進「整篇文章」是刻意的取捨(簡單);代價是看不出該來源原本想指哪個(已不存在的)段。
+- **回傳型別變更**:`getBacklinks` 由 `CollectionEntry[]` 改為 `{post, anchor}[]`;唯一呼叫端是 `PostLayout`,一併更新。
+
+## 驗證方式
+
+- 單元測試(`node --test`,純函式):
+  - `extractLinks('[[btl-5]] [[btl-5#障礙一：看不到自己]] [[#x]] [[btl-6|z]]')` → `[{slug:'btl-5',anchor:null},{slug:'btl-5',anchor:'障礙一看不到自己'},{slug:'btl-6',anchor:null}]`(同頁略過)。
+  - `extractTargets` 仍回 `['btl-5','btl-5','btl-6']`(行為不變)。
+  - `groupBySection`:給定 backlinks + headings → 正確分組、群組依標題順序、`整篇文章` 墊底、失效錨點歸入整篇、空輸入回 `[]`。
+- build + grep(用現成素材):btl-6 已 `[[btl-5#障礙一：看不到自己|…]]`,所以 build 後:
+  - `dist/blog/btl-5/index.html` 的「被引用於」區出現 section label「障礙一:看不到自己」,其下為 btl-6 的連結。
+  - 沒有 section 的純整篇引用仍出現在「整篇文章」群組。
+  - 無 backlink 的文章(如 btl-3)仍不顯示整個區塊。
+  - build 無 `[wiki-link]` warning。

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -5,9 +5,11 @@ import BaseLayout from './BaseLayout.astro';
 import AuthorCard from '../components/AuthorCard.astro';
 import Comments from '../components/Comments.astro';
 import { getBacklinks } from '../lib/backlinks';
+import { groupBySection } from '../lib/group-backlinks.mjs';
+import type { MarkdownHeading } from 'astro';
 import 'katex/dist/katex.min.css';
-interface Props { post: CollectionEntry<'blog'>; }
-const { post } = Astro.props;
+interface Props { post: CollectionEntry<'blog'>; headings?: MarkdownHeading[]; }
+const { post, headings = [] } = Astro.props;
 const { title, date, category, tags = [], series } = post.data;
 
 let seriesPosts: CollectionEntry<'blog'>[] = [];
@@ -21,7 +23,7 @@ if (series) {
   prevPost = idx > 0 ? seriesPosts[idx - 1] : null;
   nextPost = idx >= 0 && idx < seriesPosts.length - 1 ? seriesPosts[idx + 1] : null;
 }
-const backlinks = await getBacklinks(post.id);
+const backlinkGroups = groupBySection(await getBacklinks(post.id), headings);
 ---
 <BaseLayout title={title} contentLicense>
   <article>
@@ -63,14 +65,19 @@ const backlinks = await getBacklinks(post.id);
       </nav>
     )}
 
-    {backlinks.length > 0 && (
+    {backlinkGroups.length > 0 && (
       <aside class="mt-12 pt-6 border-t border-line text-sm">
         <p class="font-bold mb-2">🔗 被引用於</p>
-        <ul class="list-none p-0 m-0 space-y-1">
-          {backlinks.map((b) => (
-            <li><a href={`/blog/${b.id}/`} class="text-accent hover:underline">{b.data.title}</a></li>
-          ))}
-        </ul>
+        {backlinkGroups.map((g) => (
+          <div class="mb-3">
+            <p class="text-muted text-xs mb-1">{g.label}</p>
+            <ul class="list-none p-0 m-0 space-y-1">
+              {g.sources.map((s) => (
+                <li><a href={`/blog/${s.id}/`} class="text-accent hover:underline">{s.data.title}</a></li>
+              ))}
+            </ul>
+          </div>
+        ))}
       </aside>
     )}
 

--- a/src/lib/backlinks.ts
+++ b/src/lib/backlinks.ts
@@ -1,13 +1,28 @@
 import { getCollection } from 'astro:content';
 import type { CollectionEntry } from 'astro:content';
-import { extractTargets } from './wiki-link.mjs';
+import { extractLinks } from './wiki-link.mjs';
 
-// Posts whose body links to targetSlug via a wikilink, newest first.
-export async function getBacklinks(
-  targetSlug: string
-): Promise<CollectionEntry<'blog'>[]> {
-  const posts = await getCollection('blog');
-  return posts
-    .filter((p) => p.id !== targetSlug && extractTargets(p.body ?? '').includes(targetSlug))
+export interface BacklinkRef {
+  post: CollectionEntry<'blog'>;
+  anchor: string | null;
+}
+
+// Backlinks to targetSlug as { post, anchor } (anchor = section slug, or null
+// for a whole-post link), deduped per (post, anchor), newest post first.
+export async function getBacklinks(targetSlug: string): Promise<BacklinkRef[]> {
+  const posts = (await getCollection('blog'))
+    .filter((p) => p.id !== targetSlug)
     .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
+  const refs: BacklinkRef[] = [];
+  const seen = new Set<string>();
+  for (const post of posts) {
+    for (const { slug, anchor } of extractLinks(post.body ?? '')) {
+      if (slug !== targetSlug) continue;
+      const key = `${post.id}#${anchor ?? ''}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      refs.push({ post, anchor });
+    }
+  }
+  return refs;
 }

--- a/src/lib/group-backlinks.d.mts
+++ b/src/lib/group-backlinks.d.mts
@@ -1,0 +1,16 @@
+import type { CollectionEntry } from 'astro:content';
+
+export interface BacklinkRef {
+  post: CollectionEntry<'blog'>;
+  anchor: string | null;
+}
+
+export interface BacklinkGroup {
+  label: string;
+  sources: CollectionEntry<'blog'>[];
+}
+
+export function groupBySection(
+  backlinks: BacklinkRef[],
+  headings: { slug: string; text: string }[] | undefined
+): BacklinkGroup[];

--- a/src/lib/group-backlinks.d.mts
+++ b/src/lib/group-backlinks.d.mts
@@ -1,9 +1,7 @@
 import type { CollectionEntry } from 'astro:content';
+import type { BacklinkRef } from './backlinks';
 
-export interface BacklinkRef {
-  post: CollectionEntry<'blog'>;
-  anchor: string | null;
-}
+export type { BacklinkRef };
 
 export interface BacklinkGroup {
   label: string;

--- a/src/lib/group-backlinks.mjs
+++ b/src/lib/group-backlinks.mjs
@@ -1,11 +1,11 @@
 // Pure grouping for the "被引用於" panel. No I/O — unit-testable under node:test.
 // backlinks: Array<{ post, anchor: string|null }>  (post has .id and .data.title)
+//   Expected newest-first; this function preserves that order within each group.
 // headings:  Array<{ slug, text }>                  (the target post's own headings)
 // Returns ordered groups: sections that have sources in heading order, then a
 // single "整篇文章" group last. Whole-post links (anchor null) and anchors that
-// match no heading fold into "整篇文章". Sources within a group are deduped by
-// post.id (a post referencing both the whole post and a stale section, or the
-// same target twice, appears once per group).
+// match no heading fold into "整篇文章". Sources are deduped by post.id within a
+// group; a post shown under a specific section is NOT repeated under "整篇文章".
 const WHOLE_POST_LABEL = '整篇文章';
 
 function dedupById(posts) {
@@ -22,22 +22,27 @@ function dedupById(posts) {
 
 export function groupBySection(backlinks, headings) {
   const heads = headings ?? [];
-  const textBySlug = new Map(heads.map((h) => [h.slug, h.text]));
+  const anchorSet = new Set(heads.map((h) => h.slug));
   const sectionSources = new Map(); // anchor -> post[]
   const wholePost = [];
   for (const { post, anchor } of backlinks ?? []) {
-    if (anchor && textBySlug.has(anchor)) {
+    if (anchor && anchorSet.has(anchor)) {
       if (!sectionSources.has(anchor)) sectionSources.set(anchor, []);
       sectionSources.get(anchor).push(post);
     } else {
       wholePost.push(post);
     }
   }
+  const sectioned = new Set();
+  for (const posts of sectionSources.values()) {
+    for (const p of posts) sectioned.add(p.id);
+  }
   const groups = [];
   for (const h of heads) {
     const sources = sectionSources.get(h.slug);
     if (sources && sources.length) groups.push({ label: h.text, sources: dedupById(sources) });
   }
-  if (wholePost.length) groups.push({ label: WHOLE_POST_LABEL, sources: dedupById(wholePost) });
+  const whole = dedupById(wholePost).filter((p) => !sectioned.has(p.id));
+  if (whole.length) groups.push({ label: WHOLE_POST_LABEL, sources: whole });
   return groups;
 }

--- a/src/lib/group-backlinks.mjs
+++ b/src/lib/group-backlinks.mjs
@@ -3,8 +3,22 @@
 // headings:  Array<{ slug, text }>                  (the target post's own headings)
 // Returns ordered groups: sections that have sources in heading order, then a
 // single "整篇文章" group last. Whole-post links (anchor null) and anchors that
-// match no heading fold into "整篇文章".
+// match no heading fold into "整篇文章". Sources within a group are deduped by
+// post.id (a post referencing both the whole post and a stale section, or the
+// same target twice, appears once per group).
 const WHOLE_POST_LABEL = '整篇文章';
+
+function dedupById(posts) {
+  const seen = new Set();
+  const out = [];
+  for (const p of posts) {
+    if (!seen.has(p.id)) {
+      seen.add(p.id);
+      out.push(p);
+    }
+  }
+  return out;
+}
 
 export function groupBySection(backlinks, headings) {
   const heads = headings ?? [];
@@ -22,8 +36,8 @@ export function groupBySection(backlinks, headings) {
   const groups = [];
   for (const h of heads) {
     const sources = sectionSources.get(h.slug);
-    if (sources && sources.length) groups.push({ label: h.text, sources });
+    if (sources && sources.length) groups.push({ label: h.text, sources: dedupById(sources) });
   }
-  if (wholePost.length) groups.push({ label: WHOLE_POST_LABEL, sources: wholePost });
+  if (wholePost.length) groups.push({ label: WHOLE_POST_LABEL, sources: dedupById(wholePost) });
   return groups;
 }

--- a/src/lib/group-backlinks.mjs
+++ b/src/lib/group-backlinks.mjs
@@ -1,0 +1,29 @@
+// Pure grouping for the "被引用於" panel. No I/O — unit-testable under node:test.
+// backlinks: Array<{ post, anchor: string|null }>  (post has .id and .data.title)
+// headings:  Array<{ slug, text }>                  (the target post's own headings)
+// Returns ordered groups: sections that have sources in heading order, then a
+// single "整篇文章" group last. Whole-post links (anchor null) and anchors that
+// match no heading fold into "整篇文章".
+const WHOLE_POST_LABEL = '整篇文章';
+
+export function groupBySection(backlinks, headings) {
+  const heads = headings ?? [];
+  const textBySlug = new Map(heads.map((h) => [h.slug, h.text]));
+  const sectionSources = new Map(); // anchor -> post[]
+  const wholePost = [];
+  for (const { post, anchor } of backlinks ?? []) {
+    if (anchor && textBySlug.has(anchor)) {
+      if (!sectionSources.has(anchor)) sectionSources.set(anchor, []);
+      sectionSources.get(anchor).push(post);
+    } else {
+      wholePost.push(post);
+    }
+  }
+  const groups = [];
+  for (const h of heads) {
+    const sources = sectionSources.get(h.slug);
+    if (sources && sources.length) groups.push({ label: h.text, sources });
+  }
+  if (wholePost.length) groups.push({ label: WHOLE_POST_LABEL, sources: wholePost });
+  return groups;
+}

--- a/src/lib/wiki-link.d.mts
+++ b/src/lib/wiki-link.d.mts
@@ -17,3 +17,4 @@ export function slugifyHeading(text: string): string;
 export function parseTarget(raw: string): { slug: string; section: string | undefined };
 export function splitWikiLinks(value: string, ctx: WikiLinkContext): MdastNode[];
 export function extractTargets(body: string): string[];
+export function extractLinks(body: string): { slug: string; anchor: string | null }[];

--- a/src/lib/wiki-link.mjs
+++ b/src/lib/wiki-link.mjs
@@ -76,14 +76,22 @@ export function splitWikiLinks(value, ctx) {
   return nodes;
 }
 
-// Collect referenced base slugs (section stripped; same-page links ignored).
-export function extractTargets(body) {
+// Collect referenced links as { slug, anchor }. anchor = slugified section, or
+// null for a whole-post link. Same-page links (empty slug) are ignored.
+export function extractLinks(body) {
   const re = wikiLinkRegex();
-  const targets = [];
+  const links = [];
   let m;
   while ((m = re.exec(body ?? '')) !== null) {
-    const { slug } = parseTarget(m[1].trim());
-    if (slug !== '') targets.push(slug);
+    const { slug, section } = parseTarget(m[1].trim());
+    if (slug === '') continue;
+    const sectionText = section !== undefined ? section.trim() : '';
+    links.push({ slug, anchor: sectionText ? slugifyHeading(sectionText) : null });
   }
-  return targets;
+  return links;
+}
+
+// Collect referenced base slugs (section stripped; same-page links ignored).
+export function extractTargets(body) {
+  return extractLinks(body).map((l) => l.slug);
 }

--- a/src/lib/wiki-link.mjs
+++ b/src/lib/wiki-link.mjs
@@ -86,7 +86,7 @@ export function extractLinks(body) {
     const { slug, section } = parseTarget(m[1].trim());
     if (slug === '') continue;
     const sectionText = section !== undefined ? section.trim() : undefined;
-    links.push({ slug, anchor: sectionText ? slugifyHeading(sectionText) : null });
+    links.push({ slug, anchor: sectionText ? slugifyHeading(sectionText) || null : null });
   }
   return links;
 }

--- a/src/lib/wiki-link.mjs
+++ b/src/lib/wiki-link.mjs
@@ -85,7 +85,7 @@ export function extractLinks(body) {
   while ((m = re.exec(body ?? '')) !== null) {
     const { slug, section } = parseTarget(m[1].trim());
     if (slug === '') continue;
-    const sectionText = section !== undefined ? section.trim() : '';
+    const sectionText = section !== undefined ? section.trim() : undefined;
     links.push({ slug, anchor: sectionText ? slugifyHeading(sectionText) : null });
   }
   return links;

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -11,8 +11,8 @@ export async function getStaticPaths() {
 }
 
 const { post } = Astro.props;
-const { Content } = await render(post);
+const { Content, headings } = await render(post);
 ---
-<PostLayout post={post}>
+<PostLayout post={post} headings={headings}>
   <Content />
 </PostLayout>

--- a/test/group-backlinks.test.mjs
+++ b/test/group-backlinks.test.mjs
@@ -58,3 +58,13 @@ test('a post linking both whole-post and a stale section appears once in 整篇�
     { label: '整篇文章', sources: [post('a', 'A')] },
   ]);
 });
+
+test('a post linking both a section and the whole post appears only under the section', () => {
+  const backlinks = [
+    { post: post('a', 'A'), anchor: '反思' },
+    { post: post('a', 'A'), anchor: null },
+  ];
+  assert.deepEqual(groupBySection(backlinks, headings), [
+    { label: '反思', sources: [post('a', 'A')] },
+  ]);
+});

--- a/test/group-backlinks.test.mjs
+++ b/test/group-backlinks.test.mjs
@@ -38,3 +38,23 @@ test('handles missing headings (everything folds into 整篇文章)', () => {
     { label: '整篇文章', sources: [post('a', 'A')] },
   ]);
 });
+
+test('multiple distinct posts under the same section are all listed', () => {
+  const backlinks = [
+    { post: post('a', 'A'), anchor: '反思' },
+    { post: post('b', 'B'), anchor: '反思' },
+  ];
+  assert.deepEqual(groupBySection(backlinks, headings), [
+    { label: '反思', sources: [post('a', 'A'), post('b', 'B')] },
+  ]);
+});
+
+test('a post linking both whole-post and a stale section appears once in 整篇文章', () => {
+  const backlinks = [
+    { post: post('a', 'A'), anchor: null },
+    { post: post('a', 'A'), anchor: '已刪除的段' },
+  ];
+  assert.deepEqual(groupBySection(backlinks, headings), [
+    { label: '整篇文章', sources: [post('a', 'A')] },
+  ]);
+});

--- a/test/group-backlinks.test.mjs
+++ b/test/group-backlinks.test.mjs
@@ -1,0 +1,40 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { groupBySection } from '../src/lib/group-backlinks.mjs';
+
+const post = (id, title) => ({ id, data: { title } });
+const headings = [
+  { slug: '障礙一看不到自己', text: '障礙一：看不到自己' },
+  { slug: '反思', text: '反思' },
+];
+
+test('groups by section in heading order, 整篇文章 last', () => {
+  const backlinks = [
+    { post: post('btl-6', '用日記看見自己'), anchor: '障礙一看不到自己' },
+    { post: post('other', '某篇'), anchor: null },
+    { post: post('btl-7', '反思那篇'), anchor: '反思' },
+  ];
+  assert.deepEqual(groupBySection(backlinks, headings), [
+    { label: '障礙一：看不到自己', sources: [post('btl-6', '用日記看見自己')] },
+    { label: '反思', sources: [post('btl-7', '反思那篇')] },
+    { label: '整篇文章', sources: [post('other', '某篇')] },
+  ]);
+});
+
+test('stale anchor (no matching heading) folds into 整篇文章', () => {
+  const backlinks = [{ post: post('x', 'X'), anchor: '已刪除的段' }];
+  assert.deepEqual(groupBySection(backlinks, headings), [
+    { label: '整篇文章', sources: [post('x', 'X')] },
+  ]);
+});
+
+test('returns an empty array when there are no backlinks', () => {
+  assert.deepEqual(groupBySection([], headings), []);
+});
+
+test('handles missing headings (everything folds into 整篇文章)', () => {
+  const backlinks = [{ post: post('a', 'A'), anchor: '反思' }];
+  assert.deepEqual(groupBySection(backlinks, undefined), [
+    { label: '整篇文章', sources: [post('a', 'A')] },
+  ]);
+});

--- a/test/wiki-link.test.mjs
+++ b/test/wiki-link.test.mjs
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { splitWikiLinks, extractTargets, slugifyHeading, parseTarget } from '../src/lib/wiki-link.mjs';
+import { splitWikiLinks, extractTargets, slugifyHeading, parseTarget, extractLinks } from '../src/lib/wiki-link.mjs';
 
 const titleMap = { 'btl-3': '領導力 - 成長模型', 'btl-5': '領導力 - 創新的三大障礙' };
 const headingsMap = { 'btl-5': ['障礙一看不到自己', '反思'], 'btl-6': ['用日記看見自己'] };
@@ -100,4 +100,19 @@ test('[[slug#]] with an empty section degrades to a whole-post link', () => {
   assert.deepEqual(splitWikiLinks('[[btl-3#]]', ctx()), [
     { type: 'link', url: '/blog/btl-3/', children: [{ type: 'text', value: '領導力 - 成長模型' }] },
   ]);
+});
+
+test('extractLinks returns slug + anchor, ignoring same-page links', () => {
+  assert.deepEqual(
+    extractLinks('[[btl-5]] [[btl-5#障礙一：看不到自己]] [[#反思]] [[btl-6|z]]'),
+    [
+      { slug: 'btl-5', anchor: null },
+      { slug: 'btl-5', anchor: '障礙一看不到自己' },
+      { slug: 'btl-6', anchor: null },
+    ]
+  );
+});
+
+test('extractLinks returns an empty array for an empty body', () => {
+  assert.deepEqual(extractLinks(''), []);
 });

--- a/test/wiki-link.test.mjs
+++ b/test/wiki-link.test.mjs
@@ -116,3 +116,7 @@ test('extractLinks returns slug + anchor, ignoring same-page links', () => {
 test('extractLinks returns an empty array for an empty body', () => {
   assert.deepEqual(extractLinks(''), []);
 });
+
+test('extractLinks treats [[slug#]] (empty section) as a whole-post link', () => {
+  assert.deepEqual(extractLinks('[[btl-3#]]'), [{ slug: 'btl-3', anchor: null }]);
+});


### PR DESCRIPTION
## Summary
- 文章底部「🔗 被引用於」改為**依被引用的 section 分組**:`[[btl-5#障礙一：看不到自己]]` 會讓 btl-5 的面板把來源歸在「障礙一:看不到自己」群組底下。
- 新增純函式 `extractLinks(body)` → `{slug, anchor}[]`(anchor = slug 化的段落或 null;同頁連結略過);`extractTargets` 重構為其薄包裝(行為不變)。
- `getBacklinks` 回傳 `{post, anchor}[]`(依 (post, anchor) 去重、新到舊)。
- 純函式 `groupBySection(backlinks, headings)`(獨立檔案,可單元測試):section 群組依標題順序、「整篇文章」墊底、失效錨點歸入整篇、群組內依 post.id 去重,且**已歸到某段落的來源不再重複出現在「整篇文章」**。
- `[slug].astro` 把 `render()` 的 `headings` 傳進 `PostLayout` 渲染分組面板。
- 驗證用現成素材:btl-6 已連 `[[btl-5#障礙一：看不到自己]]`,所以 btl-5 自動把 btl-6 歸到該段落。

Spec: `docs/superpowers/specs/2026-06-13-section-backlinks-design.md`
Plan: `docs/superpowers/plans/2026-06-13-section-backlinks.md`

## Test Plan
- [x] `npm test` → 26/26 通過(extractLinks、groupBySection 的順序/分組/去重/失效錨點/同頁略過/跨群組去重)
- [x] `npm run build` → exit 0,無 `[wiki-link]` warning
- [x] btl-5 面板把 btl-6 歸在「障礙一:看不到自己」群組;btl-5 確有 `id=障礙一看不到自己`
- [x] btl-3(無人引用)不顯示面板;無 section 文章正常 build

🤖 Generated with [Claude Code](https://claude.com/claude-code)