### PR TITLE
Add rotary-dial calculator tool (轉盤計算機)

### DIFF
--- a/docs/superpowers/plans/2026-06-14-rotary-calculator.md
+++ b/docs/superpowers/plans/2026-06-14-rotary-calculator.md
@@ -1,0 +1,906 @@
+# Rotary-Dial Calculator Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a retro rotary-dial calculator — a full vintage desk telephone whose single 17-symbol dial drives a 4-function calculator that evaluates the whole expression on `=` with operator precedence.
+
+**Architecture:** Two pure, fully-tested `.mjs` modules (`calculator.mjs` math engine, `dial-geometry.mjs` dial math) plus a React island (`RotaryCalculator` → `PhoneFrame` + `NixieDisplay` + `RotaryDial`) mounted on a new Astro page and listed in the Tools hub.
+
+**Tech Stack:** Astro 6, React 19 (`@astrojs/react`, `client:load`), Tailwind v4, `node:test` for unit tests. Pure modules in `src/lib/`, components in `src/components/rotary-calculator/`.
+
+**Spec:** `docs/superpowers/specs/2026-06-14-rotary-calculator-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| `src/lib/calculator.mjs` | Pure expression engine: token reducer, precedence eval on `=`. No DOM. |
+| `src/lib/dial-geometry.mjs` | Pure dial math: hole layout, pointer→angle, rotation clamp, finger-stop detection. No DOM. |
+| `test/calculator.test.mjs` | Unit tests for the engine. |
+| `test/dial-geometry.test.mjs` | Unit tests for the geometry. |
+| `src/components/rotary-calculator/symbols.mjs` | The shared ordered list of 17 dial symbols (`{label, value}`). |
+| `src/components/rotary-calculator/NixieDisplay.jsx` | Presentational glowing readout. |
+| `src/components/rotary-calculator/RotaryDial.jsx` | SVG dial + drag/spin-back interaction; emits a symbol. |
+| `src/components/rotary-calculator/PhoneFrame.jsx` | Telephone chrome (body, handset, cradle) with display + dial slots. |
+| `src/components/rotary-calculator/RotaryCalculator.jsx` | Island container: `useReducer(calculator)`, wires dial → engine → display. |
+| `src/components/rotary-calculator/rotary-calculator.css` | Dark phone body, nixie glow, dial styling, spin animation. |
+| `src/pages/rotary-calculator.astro` | Route `/rotary-calculator/`; mounts the island via `BaseLayout`. |
+| `src/pages/tools.astro` | Add a hub card for the calculator. |
+
+---
+
+## Task 1: Calculator engine (`calculator.mjs`)
+
+**Files:**
+- Create: `src/lib/calculator.mjs`
+- Test: `test/calculator.test.mjs`
+
+The engine builds an expression as tokens arrive and evaluates only on `=`, with `×`/`÷` binding before `+`/`−`.
+
+State shape: `{ tokens, entry, display, justEvaluated, error, lastResult }` where `tokens` is the committed expression (alternating numbers and operator strings `'+' '-' '×' '÷'`), `entry` is the number currently being typed.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `test/calculator.test.mjs`:
+
+```js
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { initialState, reduce } from '../src/lib/calculator.mjs';
+
+// Feed a sequence of tokens through reduce, return final state.
+function run(tokens) {
+  return tokens.reduce(reduce, initialState());
+}
+const display = (tokens) => run(tokens).display;
+
+test('initial display is 0', () => {
+  assert.equal(initialState().display, '0');
+});
+
+test('typing digits builds the entry', () => {
+  assert.equal(display(['1', '2', '3']), '123');
+});
+
+test('leading zero is replaced by the next digit', () => {
+  assert.equal(display(['0', '5']), '5');
+  assert.equal(display(['0', '0']), '0');
+});
+
+test('decimal point is added once; a second dot is ignored', () => {
+  assert.equal(display(['1', '.', '5']), '1.5');
+  assert.equal(display(['1', '.', '5', '.', '2']), '1.52');
+});
+
+test('a leading dot becomes 0.', () => {
+  assert.equal(display(['.', '5']), '0.5');
+});
+
+test('expression string grows as operators are added', () => {
+  assert.equal(display(['2', '+', '3', '×', '4']), '2+3×4');
+});
+
+test('nothing is computed until = is pressed', () => {
+  // before '=' the display is still the expression, not 5
+  assert.equal(display(['2', '+', '3']), '2+3');
+});
+
+test('= evaluates with precedence: 2+3×4 = 14', () => {
+  assert.equal(display(['2', '+', '3', '×', '4', '=']), '14');
+});
+
+test('= respects left-to-right within a level: 8÷4÷2 = 1', () => {
+  assert.equal(display(['8', '÷', '4', '÷', '2', '=']), '1');
+});
+
+test('subtraction and addition: 10-3+1 = 8', () => {
+  assert.equal(display(['1', '0', '-', '3', '+', '1', '=']), '8');
+});
+
+test('a second operator replaces the pending one', () => {
+  assert.equal(display(['5', '+', '-', '2', '=']), '3');
+});
+
+test('after =, a digit starts a fresh expression', () => {
+  const s = run(['2', '+', '3', '=']);      // display 5
+  const s2 = reduce(s, '7');
+  assert.equal(s2.display, '7');
+});
+
+test('after =, an operator continues from the result', () => {
+  const s = run(['2', '+', '3', '=']);      // 5
+  const s2 = ['×', '4', '='].reduce(reduce, s);
+  assert.equal(s2.display, '20');
+});
+
+test('divide by zero shows Error', () => {
+  assert.equal(display(['5', '÷', '0', '=']), 'Error');
+});
+
+test('Error is cleared by starting a new number', () => {
+  const s = run(['5', '÷', '0', '=']);      // Error
+  const s2 = reduce(s, '9');
+  assert.equal(s2.display, '9');
+});
+
+test('C resets everything', () => {
+  assert.equal(display(['1', '2', '+', '3', 'C']), '0');
+});
+
+test('trailing operator before = is ignored: 2+ = 2', () => {
+  assert.equal(display(['2', '+', '=']), '2');
+});
+
+test('float noise is rounded: 0.1+0.2 = 0.3', () => {
+  assert.equal(display(['0', '.', '1', '+', '0', '.', '2', '=']), '0.3');
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npm test`
+Expected: FAIL — `Cannot find module '../src/lib/calculator.mjs'`.
+
+- [ ] **Step 3: Implement the engine**
+
+Create `src/lib/calculator.mjs`:
+
+```js
+// Pure 4-function calculator engine. No DOM, no React.
+// Builds an expression of tokens and evaluates only on '='. × ÷ bind before + −.
+
+const OPERATORS = new Set(['+', '-', '×', '÷']);
+
+export function initialState() {
+  return {
+    tokens: [],        // committed expression: [number, op, number, op, ...]
+    entry: '',         // number currently being typed
+    display: '0',
+    justEvaluated: false,
+    error: false,
+    lastResult: 0,
+  };
+}
+
+function exprString(tokens, entry) {
+  const s = tokens.map(String).join('') + entry;
+  return s === '' ? '0' : s;
+}
+
+function appendDigit(entry, d) {
+  if (entry === '0') return d === '0' ? '0' : d;
+  return entry + d;
+}
+
+// Evaluate [num, op, num, op, ...] with precedence. Throws on divide-by-zero.
+function evalExpression(tokens) {
+  const pass1 = [tokens[0]];
+  for (let i = 1; i < tokens.length; i += 2) {
+    const op = tokens[i];
+    const num = tokens[i + 1];
+    if (op === '×') {
+      pass1[pass1.length - 1] *= num;
+    } else if (op === '÷') {
+      if (num === 0) throw new Error('divide by zero');
+      pass1[pass1.length - 1] /= num;
+    } else {
+      pass1.push(op, num);
+    }
+  }
+  let acc = pass1[0];
+  for (let i = 1; i < pass1.length; i += 2) {
+    acc = pass1[i] === '+' ? acc + pass1[i + 1] : acc - pass1[i + 1];
+  }
+  return acc;
+}
+
+function formatResult(n) {
+  if (!Number.isFinite(n)) return 'Error';
+  const rounded = Number(n.toPrecision(12));
+  let s = String(rounded);
+  if (s.replace(/[-.]/g, '').length > 12) s = rounded.toExponential(6);
+  return s;
+}
+
+function inputDigit(state, d) {
+  const base = state.error || state.justEvaluated ? initialState() : state;
+  const entry = appendDigit(base.entry, d);
+  return { ...base, entry, justEvaluated: false, display: exprString(base.tokens, entry) };
+}
+
+function inputDot(state) {
+  const base = state.error || state.justEvaluated ? initialState() : state;
+  let entry = base.entry;
+  if (entry === '') entry = '0.';
+  else if (entry.includes('.')) entry = entry; // ignore second dot
+  else entry = entry + '.';
+  return { ...base, entry, justEvaluated: false, display: exprString(base.tokens, entry) };
+}
+
+function inputOperator(state, op) {
+  if (state.error) return state;
+  let tokens;
+  let entry = '';
+  if (state.justEvaluated) {
+    tokens = [state.lastResult];
+  } else {
+    tokens = state.tokens.slice();
+  }
+  if (state.entry !== '' && !state.justEvaluated) {
+    tokens.push(Number(state.entry));
+  }
+  const last = tokens[tokens.length - 1];
+  if (tokens.length === 0) return state;            // nothing to operate on
+  if (typeof last === 'string') tokens[tokens.length - 1] = op; // replace operator
+  else tokens.push(op);
+  return { ...state, tokens, entry, justEvaluated: false, error: false, display: exprString(tokens, '') };
+}
+
+function evaluate(state) {
+  if (state.error) return state;
+  const tokens = state.tokens.slice();
+  if (state.entry !== '') tokens.push(Number(state.entry));
+  if (typeof tokens[tokens.length - 1] === 'string') tokens.pop(); // drop trailing operator
+  if (tokens.length === 0) return state;
+  let result;
+  try {
+    result = evalExpression(tokens);
+  } catch {
+    return { ...initialState(), error: true, display: 'Error' };
+  }
+  if (!Number.isFinite(result)) return { ...initialState(), error: true, display: 'Error' };
+  return { ...initialState(), display: formatResult(result), lastResult: result, justEvaluated: true };
+}
+
+export function reduce(state, token) {
+  if (token === 'C') return initialState();
+  if (token === '=') return evaluate(state);
+  if (token === '.') return inputDot(state);
+  if (OPERATORS.has(token)) return inputOperator(state, token);
+  if (token >= '0' && token <= '9') return inputDigit(state, token);
+  return state; // unknown token ignored
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npm test`
+Expected: PASS — all calculator tests green (plus the existing wiki-link tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/calculator.mjs test/calculator.test.mjs
+git commit -m "feat: rotary calculator pure engine (precedence, eval on =)"
+```
+
+---
+
+## Task 2: Dial geometry (`dial-geometry.mjs`)
+
+**Files:**
+- Create: `src/lib/dial-geometry.mjs`
+- Test: `test/dial-geometry.test.mjs`
+
+Angle convention: **degrees clockwise from 12 o'clock** (0 = top, 90 = right, 180 = bottom, 270 = left). Each hole rotates clockwise to a fixed finger-stop; per-hole max rotation = stop − hole angle.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `test/dial-geometry.test.mjs`:
+
+```js
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  holeLayout, pointerAngle, holeMaxRotation, rotationFor, reachedStop,
+} from '../src/lib/dial-geometry.mjs';
+
+const close = (a, b, eps = 1e-9) => assert.ok(Math.abs(a - b) < eps, `${a} ≈ ${b}`);
+
+test('holeLayout places symbols at evenly spaced clockwise angles', () => {
+  const holes = holeLayout(['a', 'b', 'c', 'd'], { startDeg: 0, stepDeg: 90, radius: 1 });
+  assert.equal(holes.length, 4);
+  assert.deepEqual(holes.map((h) => h.angleDeg), [0, 90, 180, 270]);
+  close(holes[0].x, 0); close(holes[0].y, -1);   // top
+  close(holes[1].x, 1); close(holes[1].y, 0);    // right
+});
+
+test('pointerAngle measures clockwise from the top', () => {
+  close(pointerAngle(0, 0, 0, -1), 0);    // up = 0
+  close(pointerAngle(0, 0, 1, 0), 90);    // right = 90
+  close(pointerAngle(0, 0, 0, 1), 180);   // down = 180
+  close(pointerAngle(0, 0, -1, 0), 270);  // left = 270
+});
+
+test('holeMaxRotation is the clockwise distance to the finger stop', () => {
+  assert.equal(holeMaxRotation(0, 315), 315);
+  assert.equal(holeMaxRotation(288, 315), 27);
+});
+
+test('rotationFor clamps a clockwise drag between 0 and the max', () => {
+  assert.equal(rotationFor(0, 45, 300), 45);
+  assert.equal(rotationFor(0, 300, 300), 300);
+});
+
+test('rotationFor pins past-the-stop drags to the max', () => {
+  assert.equal(rotationFor(0, 310, 300), 300);
+});
+
+test('rotationFor treats counterclockwise jitter as 0', () => {
+  assert.equal(rotationFor(0, 340, 300), 0);
+});
+
+test('reachedStop is true only near the max rotation', () => {
+  assert.equal(reachedStop(300, 300), true);
+  assert.equal(reachedStop(100, 300), false);
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npm test`
+Expected: FAIL — `Cannot find module '../src/lib/dial-geometry.mjs'`.
+
+- [ ] **Step 3: Implement the geometry**
+
+Create `src/lib/dial-geometry.mjs`:
+
+```js
+// Pure dial geometry. Angles are degrees clockwise from 12 o'clock.
+
+export function holeLayout(symbols, { startDeg = 0, stepDeg = 18, radius = 1, cx = 0, cy = 0 } = {}) {
+  return symbols.map((symbol, i) => {
+    const angleDeg = startDeg + i * stepDeg;
+    const rad = (angleDeg * Math.PI) / 180;
+    return {
+      symbol,
+      angleDeg,
+      x: cx + radius * Math.sin(rad),
+      y: cy - radius * Math.cos(rad),
+    };
+  });
+}
+
+export function pointerAngle(cx, cy, px, py) {
+  let deg = (Math.atan2(px - cx, -(py - cy)) * 180) / Math.PI;
+  if (deg < 0) deg += 360;
+  return deg;
+}
+
+export function holeMaxRotation(holeAngleDeg, fingerStopDeg) {
+  return (fingerStopDeg - holeAngleDeg + 360) % 360;
+}
+
+export function rotationFor(grabDeg, pointerDeg, maxRot, slack = 30) {
+  const delta = (pointerDeg - grabDeg + 360) % 360;
+  if (delta <= maxRot) return delta;
+  if (delta >= 360 - slack) return 0; // counterclockwise jitter
+  return maxRot;                       // dragged past the stop
+}
+
+export function reachedStop(rotation, maxRot, threshold = 0.9) {
+  return rotation >= maxRot * threshold;
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npm test`
+Expected: PASS — all dial-geometry tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/dial-geometry.mjs test/dial-geometry.test.mjs
+git commit -m "feat: pure dial geometry helpers"
+```
+
+---
+
+## Task 3: Page scaffold, hub entry, and dial symbols
+
+Stand up the route and island plumbing with a placeholder, so the build is green before adding UI.
+
+**Files:**
+- Create: `src/components/rotary-calculator/symbols.mjs`
+- Create: `src/components/rotary-calculator/RotaryCalculator.jsx`
+- Create: `src/components/rotary-calculator/rotary-calculator.css`
+- Create: `src/pages/rotary-calculator.astro`
+- Modify: `src/pages/tools.astro`
+
+- [ ] **Step 1: Create the shared symbol list**
+
+Create `src/components/rotary-calculator/symbols.mjs`:
+
+```js
+// The 17 symbols on the dial, in clockwise order. `label` is the glyph shown;
+// `value` is the token fed to the calculator engine.
+export const DIAL_SYMBOLS = [
+  { label: '1', value: '1' }, { label: '2', value: '2' }, { label: '3', value: '3' },
+  { label: '4', value: '4' }, { label: '5', value: '5' }, { label: '6', value: '6' },
+  { label: '7', value: '7' }, { label: '8', value: '8' }, { label: '9', value: '9' },
+  { label: '0', value: '0' }, { label: '.', value: '.' },
+  { label: '+', value: '+' }, { label: '−', value: '-' },
+  { label: '×', value: '×' }, { label: '÷', value: '÷' },
+  { label: '=', value: '=' }, { label: 'C', value: 'C' },
+];
+```
+
+- [ ] **Step 2: Create a minimal island and its CSS**
+
+Create `src/components/rotary-calculator/rotary-calculator.css`:
+
+```css
+.rc-stage {
+  display: flex;
+  justify-content: center;
+  padding: 1.5rem 0;
+}
+```
+
+Create `src/components/rotary-calculator/RotaryCalculator.jsx`:
+
+```jsx
+import './rotary-calculator.css';
+
+export default function RotaryCalculator() {
+  return (
+    <div className="rc-stage">
+      <p>Rotary calculator coming soon.</p>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Create the page**
+
+Create `src/pages/rotary-calculator.astro`:
+
+```astro
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import RotaryCalculator from '../components/rotary-calculator/RotaryCalculator.jsx';
+---
+<BaseLayout title="轉盤計算機">
+  <h1 class="text-2xl font-bold mb-6">轉盤計算機</h1>
+  <RotaryCalculator client:load />
+</BaseLayout>
+```
+
+- [ ] **Step 4: Add the Tools hub card**
+
+In `src/pages/tools.astro`, add this entry to the `tools` array (after the MBTI entry):
+
+```js
+  { icon: '☎️', title: '轉盤計算機', href: '/rotary-calculator/', desc: '用古董轉盤電話打數字的計算機', external: false },
+```
+
+- [ ] **Step 5: Verify the build and route**
+
+Run: `npm run build`
+Expected: build succeeds; output includes `dist/rotary-calculator/index.html`.
+
+Run: `node --test test/**/*.mjs` (i.e. `npm test`)
+Expected: still PASS (no regressions).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/rotary-calculator/symbols.mjs src/components/rotary-calculator/RotaryCalculator.jsx src/components/rotary-calculator/rotary-calculator.css src/pages/rotary-calculator.astro src/pages/tools.astro
+git commit -m "feat: scaffold rotary-calculator page + tools hub entry"
+```
+
+---
+
+## Task 4: Nixie display + engine wiring
+
+Render the glowing readout and drive it from the engine via a temporary keyboard hook so the math is observable before the dial exists.
+
+**Files:**
+- Create: `src/components/rotary-calculator/NixieDisplay.jsx`
+- Modify: `src/components/rotary-calculator/RotaryCalculator.jsx`
+- Modify: `src/components/rotary-calculator/rotary-calculator.css`
+
+- [ ] **Step 1: Create the NixieDisplay component**
+
+Create `src/components/rotary-calculator/NixieDisplay.jsx`:
+
+```jsx
+export default function NixieDisplay({ text }) {
+  return (
+    <div className="rc-nixie" aria-live="polite">
+      <span className="rc-nixie-text">{text}</span>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Wire the engine into the container**
+
+Replace `src/components/rotary-calculator/RotaryCalculator.jsx` with:
+
+```jsx
+import { useReducer, useEffect } from 'react';
+import { initialState, reduce } from '../../lib/calculator.mjs';
+import { DIAL_SYMBOLS } from './symbols.mjs';
+import NixieDisplay from './NixieDisplay.jsx';
+import './rotary-calculator.css';
+
+export default function RotaryCalculator() {
+  const [state, dispatch] = useReducer(reduce, undefined, initialState);
+
+  // Temporary: keyboard input so the engine is testable before the dial lands.
+  // Removed in Task 5 once the dial drives dispatch.
+  useEffect(() => {
+    const keyToken = (k) => {
+      if (k >= '0' && k <= '9') return k;
+      if (k === '.') return '.';
+      if (k === '+') return '+';
+      if (k === '-') return '-';
+      if (k === '*') return '×';
+      if (k === '/') return '÷';
+      if (k === 'Enter' || k === '=') return '=';
+      if (k === 'Escape' || k === 'c' || k === 'C') return 'C';
+      return null;
+    };
+    const onKey = (e) => {
+      const t = keyToken(e.key);
+      if (t) { e.preventDefault(); dispatch(t); }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, []);
+
+  return (
+    <div className="rc-stage">
+      <NixieDisplay text={state.display} />
+      {/* dial added in Task 5; symbols list ready: */}
+      <ul className="rc-symbol-preview">
+        {DIAL_SYMBOLS.map((s) => <li key={s.value}>{s.label}</li>)}
+      </ul>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Add nixie styling**
+
+Append to `src/components/rotary-calculator/rotary-calculator.css`:
+
+```css
+.rc-stage { flex-direction: column; align-items: center; gap: 1rem; }
+
+.rc-nixie {
+  background: #000;
+  border: 1px solid #2a2118;
+  border-radius: 6px;
+  padding: 0.5rem 1rem;
+  min-width: 14rem;
+  text-align: right;
+}
+.rc-nixie-text {
+  font-family: 'Courier New', monospace;
+  font-size: 2rem;
+  letter-spacing: 0.15em;
+  color: #ff9a3c;
+  text-shadow: 0 0 6px #ff7a00, 0 0 16px #ff5500;
+}
+.rc-symbol-preview { display: none; } /* preview only; dial replaces it in Task 5 */
+```
+
+- [ ] **Step 4: Verify in the browser**
+
+Run: `npm run dev`
+Open `http://localhost:4321/rotary-calculator/`. Type `2+3*4` then Enter.
+Expected: the nixie display shows `2+3×4`, then `14` after Enter. `Escape` resets to `0`.
+
+- [ ] **Step 5: Verify build + tests**
+
+Run: `npm run build && npm test`
+Expected: build succeeds, all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/rotary-calculator/NixieDisplay.jsx src/components/rotary-calculator/RotaryCalculator.jsx src/components/rotary-calculator/rotary-calculator.css
+git commit -m "feat: nixie display wired to calculator engine"
+```
+
+---
+
+## Task 5: Rotary dial with drag + spin-back
+
+Build the interactive dial and replace the keyboard stub. The dial owns all pointer handling and uses `dial-geometry.mjs`.
+
+**Files:**
+- Create: `src/components/rotary-calculator/RotaryDial.jsx`
+- Modify: `src/components/rotary-calculator/RotaryCalculator.jsx`
+- Modify: `src/components/rotary-calculator/rotary-calculator.css`
+
+Layout constants: 17 holes from `startDeg = 0`, `stepDeg = 18` (0…288°); finger stop at `330°`; SVG viewBox `0 0 320 320`, center `(160, 160)`, hole radius `122`.
+
+- [ ] **Step 1: Create the RotaryDial component**
+
+Create `src/components/rotary-calculator/RotaryDial.jsx`:
+
+```jsx
+import { useRef, useState } from 'react';
+import { holeLayout, pointerAngle, holeMaxRotation, rotationFor, reachedStop } from '../../lib/dial-geometry.mjs';
+
+const CX = 160, CY = 160, HOLE_R = 122, FINGER_STOP_DEG = 330;
+const LAYOUT_OPTS = { startDeg: 0, stepDeg: 18, radius: HOLE_R, cx: CX, cy: CY };
+
+export default function RotaryDial({ symbols, onDial }) {
+  const svgRef = useRef(null);
+  const drag = useRef(null);                 // { grabDeg, maxRot, value }
+  const [rotation, setRotation] = useState(0);
+  const [spinning, setSpinning] = useState(false);
+
+  const holes = holeLayout(symbols.map((s) => s.label), LAYOUT_OPTS);
+
+  const svgAngle = (e) => {
+    const rect = svgRef.current.getBoundingClientRect();
+    const scale = 320 / rect.width;
+    const px = (e.clientX - rect.left) * scale;
+    const py = (e.clientY - rect.top) * scale;
+    return pointerAngle(CX, CY, px, py);
+  };
+
+  const onPointerDown = (e, sym, angleDeg) => {
+    if (spinning) return;
+    e.currentTarget.setPointerCapture(e.pointerId);
+    drag.current = { grabDeg: angleDeg, maxRot: holeMaxRotation(angleDeg, FINGER_STOP_DEG), value: sym.value };
+    setRotation(0);
+  };
+
+  const onPointerMove = (e) => {
+    if (!drag.current) return;
+    const { grabDeg, maxRot } = drag.current;
+    setRotation(rotationFor(grabDeg, svgAngle(e), maxRot));
+  };
+
+  const onPointerUp = () => {
+    if (!drag.current) return;
+    const { maxRot, value } = drag.current;
+    const registered = reachedStop(rotation, maxRot);
+    drag.current = null;
+    if (rotation > 0) {                       // only animate (and arm onTransitionEnd) if we actually moved
+      setSpinning(true);                      // CSS transition animates rotation → 0
+      setRotation(0);
+    }
+    if (registered) onDial(value);
+  };
+
+  return (
+    <svg
+      ref={svgRef}
+      className="rc-dial"
+      viewBox="0 0 320 320"
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+      onPointerCancel={onPointerUp}
+    >
+      <circle cx={CX} cy={CY} r="150" className="rc-dial-face" />
+      <g
+        className={spinning ? 'rc-dial-rotor rc-spinning' : 'rc-dial-rotor'}
+        style={{ transform: `rotate(${rotation}deg)`, transformOrigin: `${CX}px ${CY}px` }}
+        onTransitionEnd={() => setSpinning(false)}
+      >
+        {holes.map((h, i) => (
+          <g
+            key={symbols[i].value}
+            className="rc-hole"
+            onPointerDown={(e) => onPointerDown(e, symbols[i], h.angleDeg)}
+          >
+            <circle cx={h.x} cy={h.y} r="20" className="rc-hole-bg" />
+            <text x={h.x} y={h.y} className="rc-hole-label" dominantBaseline="central" textAnchor="middle">
+              {h.symbol}
+            </text>
+          </g>
+        ))}
+      </g>
+      <circle cx={CX} cy={CY} r="46" className="rc-dial-hub" />
+      <rect x={CX + 96} y={CY + 70} width="26" height="16" rx="3" className="rc-finger-stop" />
+    </svg>
+  );
+}
+```
+
+- [ ] **Step 2: Replace the keyboard stub with the dial**
+
+Replace `src/components/rotary-calculator/RotaryCalculator.jsx` with:
+
+```jsx
+import { useReducer } from 'react';
+import { initialState, reduce } from '../../lib/calculator.mjs';
+import { DIAL_SYMBOLS } from './symbols.mjs';
+import NixieDisplay from './NixieDisplay.jsx';
+import RotaryDial from './RotaryDial.jsx';
+import './rotary-calculator.css';
+
+export default function RotaryCalculator() {
+  const [state, dispatch] = useReducer(reduce, undefined, initialState);
+  return (
+    <div className="rc-stage">
+      <NixieDisplay text={state.display} />
+      <RotaryDial symbols={DIAL_SYMBOLS} onDial={dispatch} />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Add dial styling + spin animation**
+
+Append to `src/components/rotary-calculator/rotary-calculator.css`:
+
+```css
+.rc-dial { width: 320px; max-width: 90vw; touch-action: none; user-select: none; }
+.rc-dial-face { fill: #1c1c22; stroke: #2a2a33; stroke-width: 2; }
+.rc-dial-hub { fill: #0e0e12; }
+.rc-dial-rotor.rc-spinning { transition: transform 0.5s cubic-bezier(0.4, 1.4, 0.6, 1); }
+.rc-hole { cursor: grab; }
+.rc-hole-bg { fill: #000; stroke: #ff9a3c; stroke-width: 1; }
+.rc-hole-label {
+  fill: #ff9a3c; font-family: Georgia, serif; font-size: 18px;
+  text-shadow: 0 0 4px #ff7a00; pointer-events: none;
+}
+.rc-finger-stop { fill: #c0392b; }
+```
+
+- [ ] **Step 4: Verify the dial in the browser**
+
+Run: `npm run dev`
+Open `http://localhost:4321/rotary-calculator/`. Drag the `2` hole clockwise to the finger stop and release; the dial spins back and `2` registers. Dial `2 + 3 × 4 =` and confirm `14`. Confirm a short drag that doesn't reach the stop registers nothing.
+
+- [ ] **Step 5: Verify build + tests**
+
+Run: `npm run build && npm test`
+Expected: build succeeds, all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/rotary-calculator/RotaryDial.jsx src/components/rotary-calculator/RotaryCalculator.jsx src/components/rotary-calculator/rotary-calculator.css
+git commit -m "feat: interactive rotary dial with drag and spin-back"
+```
+
+---
+
+## Task 6: Telephone chrome (`PhoneFrame`)
+
+Wrap the display and dial in a vintage desk-phone body with a handset on the cradle.
+
+**Files:**
+- Create: `src/components/rotary-calculator/PhoneFrame.jsx`
+- Modify: `src/components/rotary-calculator/RotaryCalculator.jsx`
+- Modify: `src/components/rotary-calculator/rotary-calculator.css`
+
+- [ ] **Step 1: Create the PhoneFrame component**
+
+Create `src/components/rotary-calculator/PhoneFrame.jsx`:
+
+```jsx
+// Presentational telephone chrome. `display` renders in the strip above the
+// dial; `children` (the dial) sit in the body.
+export default function PhoneFrame({ display, children }) {
+  return (
+    <div className="rc-phone">
+      <div className="rc-handset">
+        <span className="rc-earpiece" />
+        <span className="rc-handle" />
+        <span className="rc-earpiece" />
+      </div>
+      <div className="rc-body">
+        <div className="rc-display-strip">{display}</div>
+        <div className="rc-dial-mount">{children}</div>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Compose it into the container**
+
+Replace `src/components/rotary-calculator/RotaryCalculator.jsx` with:
+
+```jsx
+import { useReducer } from 'react';
+import { initialState, reduce } from '../../lib/calculator.mjs';
+import { DIAL_SYMBOLS } from './symbols.mjs';
+import NixieDisplay from './NixieDisplay.jsx';
+import RotaryDial from './RotaryDial.jsx';
+import PhoneFrame from './PhoneFrame.jsx';
+import './rotary-calculator.css';
+
+export default function RotaryCalculator() {
+  const [state, dispatch] = useReducer(reduce, undefined, initialState);
+  return (
+    <div className="rc-stage">
+      <PhoneFrame display={<NixieDisplay text={state.display} />}>
+        <RotaryDial symbols={DIAL_SYMBOLS} onDial={dispatch} />
+      </PhoneFrame>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Add the phone chrome styling**
+
+Append to `src/components/rotary-calculator/rotary-calculator.css`:
+
+```css
+.rc-phone { display: flex; flex-direction: column; align-items: center; }
+.rc-handset {
+  display: flex; align-items: center; width: 19rem; max-width: 88vw; height: 2.6rem;
+  margin-bottom: -0.8rem; z-index: 2;
+}
+.rc-earpiece {
+  width: 3.2rem; height: 2.6rem; border-radius: 1.3rem / 1.1rem;
+  background: linear-gradient(160deg, #2a2a30, #0c0c10);
+  border: 1px solid #3a3a42;
+}
+.rc-handle { flex: 1; height: 1.2rem; background: #0e0e12; border: 1px solid #3a3a42; border-radius: 0.6rem; }
+.rc-body {
+  background: radial-gradient(circle at 40% 25%, #26262c, #111114);
+  border: 2px solid #3a3a42; border-radius: 1.5rem 1.5rem 2rem 2rem;
+  padding: 1.6rem 1.4rem 2rem; display: flex; flex-direction: column;
+  align-items: center; gap: 1.1rem; box-shadow: 0 10px 28px rgba(0,0,0,.5);
+}
+.rc-display-strip { width: 100%; display: flex; justify-content: center; }
+.rc-dial-mount { display: flex; justify-content: center; }
+```
+
+- [ ] **Step 4: Verify the whole phone in the browser**
+
+Run: `npm run dev`
+Open `http://localhost:4321/rotary-calculator/`. Confirm a recognizable desk phone: handset across the top, nixie strip below it, dial mounted in the body. Dial `7 ÷ 2 =` → `3.5`. Resize to a narrow viewport and confirm it stays usable.
+
+- [ ] **Step 5: Verify build + tests**
+
+Run: `npm run build && npm test`
+Expected: build succeeds, all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/rotary-calculator/PhoneFrame.jsx src/components/rotary-calculator/RotaryCalculator.jsx src/components/rotary-calculator/rotary-calculator.css
+git commit -m "feat: vintage telephone chrome around the dial"
+```
+
+---
+
+## Task 7: Final verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Full test + build**
+
+Run: `npm test && npm run build`
+Expected: all unit tests pass; production build succeeds with `dist/rotary-calculator/index.html` present.
+
+- [ ] **Step 2: Manual acceptance pass**
+
+Run: `npm run dev` and at `http://localhost:4321/rotary-calculator/` confirm each:
+- Dialing digits builds the expression on the nixie display.
+- `2 + 3 × 4 =` → `14` (precedence holds).
+- `5 ÷ 0 =` → `Error`; dialing a digit clears it.
+- `C` resets to `0`.
+- A drag that doesn't reach the finger stop registers nothing.
+- Input is ignored while the dial is spinning back.
+- The Tools hub (`/tools/`) shows the ☎️ 轉盤計算機 card linking here.
+
+- [ ] **Step 3: Confirm clean tree**
+
+Run: `git status`
+Expected: working tree clean (everything committed across Tasks 1–6).
+
+---
+
+## Notes for the implementer
+
+- **Operator glyphs vs tokens:** the dial shows `−` (U+2212) but the engine token is ASCII `-`; the mapping lives in `symbols.mjs` (`label` vs `value`). Don't feed labels to the engine.
+- **Why a keyboard stub in Task 4:** it makes the engine observable in-browser one task before the dial exists, then is deleted in Task 5. This keeps each task independently verifiable.
+- **Geometry is pure:** all dial math is unit-tested in `dial-geometry.mjs`; `RotaryDial.jsx` only translates pointer events into calls to those functions, so the untested surface stays thin.
+```

--- a/docs/superpowers/specs/2026-06-14-rotary-calculator-design.md
+++ b/docs/superpowers/specs/2026-06-14-rotary-calculator-design.md
@@ -15,7 +15,9 @@ and the dial.
 One dial carries **all 17 symbols** — `0 1 2 3 4 5 6 7 8 9 . + − × ÷ = C` — and is
 operated with **full skeuomorphic drag**: grab a hole, drag clockwise to the
 finger-stop, release; the dial spins itself back, and the symbol registers when
-the dial returns home. The calculator does **4-function math with decimals**.
+the dial returns home. The calculator does **4-function math with decimals**,
+building up the full expression and evaluating it **only on `=`** with standard
+operator precedence (`2 + 3 × 4 =` → `14`).
 
 This is the site's first React-island tool (existing tools are vanilla-JS
 `.astro` pages). React 19 + `@astrojs/react` are already configured.
@@ -30,7 +32,7 @@ This is the site's first React-island tool (existing tools are vanilla-JS
 | Aesthetic / display | **Dark retro-tech** with a glowing-orange **nixie** readout |
 | Form factor | **Whole desk telephone** — handset on cradle + dial on the body |
 | Display placement | **Nixie strip on the phone body, above the dial** |
-| Evaluation model | **Immediate-execution** (`2 + 3 × 4 =` → `20`, like a pocket calculator) |
+| Evaluation model | **Expression with precedence, evaluated on `=`** (`2 + 3 × 4 =` → `14`; `×` `÷` bind before `+` `−`) |
 
 ## Architecture
 
@@ -38,22 +40,32 @@ A small set of isolated units, each with one job:
 
 ### `src/lib/calculator.mjs` — pure math engine
 - No React, no DOM. The TDD target.
-- Immediate-execution 4-function state machine over single tokens.
+- Builds up a **full expression** as tokens are entered and only **evaluates on
+  `=`**, applying standard precedence (`×` `÷` before `+` `−`), left-to-right
+  within the same precedence level.
 - **API:** `initialState()` and `reduce(state, token) → state`, where
   `token ∈ { '0'…'9', '.', '+', '-', '×', '÷', '=', 'C' }`.
-- **State:** current entry string, accumulator, pending operator,
-  `display` string, `justEvaluated` flag, `error` flag.
+- **State:** the expression so far (list of numbers/operators), the
+  current entry string, a `display` string, a `justEvaluated` flag, and an
+  `error` flag.
 - **Semantics:**
   - Digits append to the current entry; leading-zero normalized.
   - `.` is ignored if the current entry already has one.
-  - An operator commits the current entry and stores the pending op; pressing a
-    second operator before entering a number **replaces** the pending op.
-  - `=` applies the pending op to (accumulator, current entry) and shows the result.
+  - An operator commits the current entry into the expression and appends the
+    operator; pressing a second operator before entering a number **replaces**
+    the trailing operator. **No arithmetic happens here** — the expression just
+    grows.
+  - `=` evaluates the **entire** expression with precedence and shows the result.
+    Evaluation happens *only* on `=`.
+  - After `=`: a digit starts a fresh expression; an operator continues from the
+    result.
   - `C` resets to `initialState()`.
-  - Divide-by-zero → `error` state, `display = "Error"`; cleared by `C` or by
-    starting a new number.
+  - Divide-by-zero (detected at `=`) → `error` state, `display = "Error"`;
+    cleared by `C` or by starting a new number.
   - Overlong results are truncated to the display width, falling back to
     exponential notation when they don't fit.
+- **Display while building:** the readout shows the expression as it grows
+  (e.g. `2+3×4`), then the result (`14`) after `=`.
 
 ### `src/lib/dial-geometry.mjs` — pure geometry helpers
 - No DOM. Unit-tested.
@@ -124,7 +136,9 @@ drag hole → release at finger-stop
 
 - **TDD (`node --test test/**/*.mjs`, the repo convention):**
   - `calculator.mjs`: digit & decimal entry, leading-zero normalization, each of
-    `+ − × ÷`, operator chaining under immediate-execution, `=`, `C`,
+    `+ − × ÷`, **precedence** (`2+3×4=` → `14`, `×`/`÷` before `+`/`−`),
+    left-to-right within a level, evaluation happening **only** on `=`,
+    continue-from-result vs. fresh-start after `=`, `C`,
     divide-by-zero → `Error`, double-`.` guard, operator replacement, overflow.
   - `dial-geometry.mjs`: hole layout angles, pointer→angle, clamped rotation,
     `reachedStop` threshold (reaches vs. falls short).

--- a/docs/superpowers/specs/2026-06-14-rotary-calculator-design.md
+++ b/docs/superpowers/specs/2026-06-14-rotary-calculator-design.md
@@ -1,0 +1,141 @@
+# Rotary-Dial Calculator — Design
+
+**Date:** 2026-06-14
+**Status:** Approved design, pending spec review
+**Route:** `/rotary-calculator/`
+
+## Summary
+
+A retro **rotary-dial calculator** rendered as a React island on a new tool page,
+added to the Tools hub. The whole UI is a **1950s desk telephone**: a handset
+resting on the cradle, a single rotary dial mounted on the phone body, and a
+glowing **nixie-style display strip** set into the phone face between the handset
+and the dial.
+
+One dial carries **all 17 symbols** — `0 1 2 3 4 5 6 7 8 9 . + − × ÷ = C` — and is
+operated with **full skeuomorphic drag**: grab a hole, drag clockwise to the
+finger-stop, release; the dial spins itself back, and the symbol registers when
+the dial returns home. The calculator does **4-function math with decimals**.
+
+This is the site's first React-island tool (existing tools are vanilla-JS
+`.astro` pages). React 19 + `@astrojs/react` are already configured.
+
+## Decisions (locked during brainstorming)
+
+| Question | Decision |
+| --- | --- |
+| Operator input | **One big dial** holds digits *and* operators (no separate buttons) |
+| Dialing interaction | **Full skeuomorphic drag** to finger-stop, with spin-back; registers on return |
+| Math scope | **4-function with decimals** (`+ − × ÷ =`, `.`, `C`) |
+| Aesthetic / display | **Dark retro-tech** with a glowing-orange **nixie** readout |
+| Form factor | **Whole desk telephone** — handset on cradle + dial on the body |
+| Display placement | **Nixie strip on the phone body, above the dial** |
+| Evaluation model | **Immediate-execution** (`2 + 3 × 4 =` → `20`, like a pocket calculator) |
+
+## Architecture
+
+A small set of isolated units, each with one job:
+
+### `src/lib/calculator.mjs` — pure math engine
+- No React, no DOM. The TDD target.
+- Immediate-execution 4-function state machine over single tokens.
+- **API:** `initialState()` and `reduce(state, token) → state`, where
+  `token ∈ { '0'…'9', '.', '+', '-', '×', '÷', '=', 'C' }`.
+- **State:** current entry string, accumulator, pending operator,
+  `display` string, `justEvaluated` flag, `error` flag.
+- **Semantics:**
+  - Digits append to the current entry; leading-zero normalized.
+  - `.` is ignored if the current entry already has one.
+  - An operator commits the current entry and stores the pending op; pressing a
+    second operator before entering a number **replaces** the pending op.
+  - `=` applies the pending op to (accumulator, current entry) and shows the result.
+  - `C` resets to `initialState()`.
+  - Divide-by-zero → `error` state, `display = "Error"`; cleared by `C` or by
+    starting a new number.
+  - Overlong results are truncated to the display width, falling back to
+    exponential notation when they don't fit.
+
+### `src/lib/dial-geometry.mjs` — pure geometry helpers
+- No DOM. Unit-tested.
+- **Responsibilities:** lay out the 17 holes at their angles around the dial;
+  convert a pointer position to an angle; compute current rotation while dragging
+  (clamped between the grabbed hole's home angle and the finger-stop); decide
+  whether a release **reached the finger-stop** (i.e. registers) or falls short.
+- **Example API:** `holeLayout(symbols) → [{symbol, angleDeg, x, y}]`,
+  `pointerAngle(cx, cy, px, py) → deg`,
+  `rotationFor(grabAngle, pointerAngle, stopAngle) → deg`,
+  `reachedStop(rotation, stopAngle) → boolean`.
+
+### `RotaryDial.jsx` — the interactive dial (presentational + interaction)
+- Renders the SVG dial and 17 holes; owns **all** pointer-drag, rotation, and
+  spin-back animation. Knows nothing about arithmetic.
+- **Props:** `symbols: string[]`, `onDial(symbol)`, `disabled?`.
+- **Interaction:**
+  1. `pointerdown` on a hole captures the pointer and records the grabbed hole.
+  2. `pointermove` rotates the whole dial so the grabbed hole tracks toward the
+     finger-stop (clamped via `dial-geometry`).
+  3. `pointerup`: if the drag reached the stop, call `onDial(symbol)`; then
+     animate the dial back home (timed ease-out, roughly proportional to travel).
+  4. While spinning back, **ignore new input** (mimics a real dial).
+- Works with mouse and touch (Pointer Events).
+
+### `NixieDisplay.jsx` — the readout (presentational)
+- **Props:** `text: string`. Renders the glowing-orange nixie panel inside the
+  body strip. Right-aligned; handles overflow / `Error`.
+
+### `PhoneFrame` (phone chrome) — presentational
+- The telephone body, handset, and cradle (SVG / CSS). Provides the layout slots:
+  the **display strip** (top) and the **dial mount** (center). May start as markup
+  inside `RotaryCalculator.jsx` and be extracted to `PhoneFrame.jsx` if it grows.
+
+### `RotaryCalculator.jsx` — container island
+- Holds engine state with `useReducer(reduce, initialState())`.
+- Composes `PhoneFrame` → `NixieDisplay` (display strip) + `RotaryDial` (mount).
+- `onDial(symbol)` dispatches the token; `state.display` feeds `NixieDisplay`.
+
+### `src/pages/rotary-calculator.astro` — page
+- Uses `BaseLayout`; mounts `<RotaryCalculator client:load />`.
+- Imports a dedicated CSS file for the dark phone body, nixie glow, and dial
+  styling (custom enough to warrant its own stylesheet rather than Tailwind utilities).
+
+### `src/pages/tools.astro` — hub entry
+- Add `{ icon: '☎️', title: '轉盤計算機', href: '/rotary-calculator/', desc: '用古董轉盤電話打數字的計算機', external: false }`.
+
+## Data flow
+
+```
+drag hole → release at finger-stop
+  → RotaryDial.onDial(symbol)
+    → dispatch(token) → calculator.reduce → new state.display
+      → NixieDisplay re-renders
+(dial spin-back animation runs independently of the math)
+```
+
+## Error handling
+
+- Divide-by-zero → `display = "Error"`, cleared by `C` or starting a new number.
+- Second `.` within one number is ignored.
+- Two operators in a row → the pending operator is replaced.
+- Overlong results → truncate to display width, fall back to exponential.
+- `=` with no pending operator → no-op (display unchanged).
+- Input during spin-back → ignored.
+
+## Testing
+
+- **TDD (`node --test test/**/*.mjs`, the repo convention):**
+  - `calculator.mjs`: digit & decimal entry, leading-zero normalization, each of
+    `+ − × ÷`, operator chaining under immediate-execution, `=`, `C`,
+    divide-by-zero → `Error`, double-`.` guard, operator replacement, overflow.
+  - `dial-geometry.mjs`: hole layout angles, pointer→angle, clamped rotation,
+    `reachedStop` threshold (reaches vs. falls short).
+- **Manual:** dial *feel* (drag, finger-stop, spin-back, input lockout) verified
+  via `npm run dev` and the visual companion — drag interaction isn't meaningfully
+  unit-testable.
+
+## Out of scope (YAGNI)
+
+- Memory keys (M+, M−, MR), `%`, `±`, backspace.
+- Scientific functions, history/paper-tape log.
+- Keyboard input (dial-only by design; may revisit for accessibility later).
+- Sound effects (could be a nice follow-up, not part of v1).
+```

--- a/src/components/rotary-calculator/HistoryPanel.jsx
+++ b/src/components/rotary-calculator/HistoryPanel.jsx
@@ -1,0 +1,21 @@
+// Presentational running log of past calculations (newest first).
+export default function HistoryPanel({ entries }) {
+  return (
+    <aside className="rc-history" aria-label="計算紀錄">
+      <h2 className="rc-history-title">紀錄</h2>
+      {entries.length === 0 ? (
+        <p className="rc-history-empty">還沒有計算紀錄</p>
+      ) : (
+        <ul className="rc-history-list">
+          {entries.map((e) => (
+            <li key={e.id} className="rc-history-item">
+              <span className="rc-history-expr">{e.expr}</span>
+              <span className="rc-history-eq">=</span>
+              <span className="rc-history-result">{e.result}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </aside>
+  );
+}

--- a/src/components/rotary-calculator/NixieDisplay.jsx
+++ b/src/components/rotary-calculator/NixieDisplay.jsx
@@ -1,0 +1,7 @@
+export default function NixieDisplay({ text }) {
+  return (
+    <div className="rc-nixie" aria-live="polite">
+      <span className="rc-nixie-text">{text}</span>
+    </div>
+  );
+}

--- a/src/components/rotary-calculator/PhoneFrame.jsx
+++ b/src/components/rotary-calculator/PhoneFrame.jsx
@@ -1,13 +1,19 @@
-// Presentational telephone chrome. `display` renders in the strip above the
-// dial; `children` (the dial) sit in the body.
+// Presentational telephone chrome. A receiver (handset) rests on the cradle
+// above the body; `display` renders in the strip; `children` (the dial) sit in
+// the body.
 export default function PhoneFrame({ display, children }) {
   return (
     <div className="rc-phone">
-      <div className="rc-handset">
-        <span className="rc-earpiece" />
-        <span className="rc-handle" />
-        <span className="rc-earpiece" />
-      </div>
+      <svg className="rc-handset" viewBox="0 0 320 108" aria-hidden="true">
+        {/* cradle hooks the receiver rests on */}
+        <rect className="rc-cradle" x="54" y="86" width="44" height="14" rx="5" />
+        <rect className="rc-cradle" x="222" y="86" width="44" height="14" rx="5" />
+        {/* arched handle */}
+        <path className="rc-handset-handle" d="M76 74 Q76 22 160 22 Q244 22 244 74" />
+        {/* ear / mouth pieces pointing down into the cradle */}
+        <ellipse className="rc-handset-bulb" cx="76" cy="76" rx="32" ry="24" />
+        <ellipse className="rc-handset-bulb" cx="244" cy="76" rx="32" ry="24" />
+      </svg>
       <div className="rc-body">
         <div className="rc-display-strip">{display}</div>
         <div className="rc-dial-mount">{children}</div>

--- a/src/components/rotary-calculator/PhoneFrame.jsx
+++ b/src/components/rotary-calculator/PhoneFrame.jsx
@@ -1,0 +1,17 @@
+// Presentational telephone chrome. `display` renders in the strip above the
+// dial; `children` (the dial) sit in the body.
+export default function PhoneFrame({ display, children }) {
+  return (
+    <div className="rc-phone">
+      <div className="rc-handset">
+        <span className="rc-earpiece" />
+        <span className="rc-handle" />
+        <span className="rc-earpiece" />
+      </div>
+      <div className="rc-body">
+        <div className="rc-display-strip">{display}</div>
+        <div className="rc-dial-mount">{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/rotary-calculator/RotaryCalculator.jsx
+++ b/src/components/rotary-calculator/RotaryCalculator.jsx
@@ -1,18 +1,20 @@
 import { useReducer } from 'react';
-import { initialState, reduce } from '../../lib/calculator.mjs';
+import { initWithHistory, reduceWithHistory } from '../../lib/calculator-history.mjs';
 import { DIAL_SYMBOLS } from './symbols.mjs';
 import NixieDisplay from './NixieDisplay.jsx';
 import RotaryDial from './RotaryDial.jsx';
 import PhoneFrame from './PhoneFrame.jsx';
+import HistoryPanel from './HistoryPanel.jsx';
 import './rotary-calculator.css';
 
 export default function RotaryCalculator() {
-  const [state, dispatch] = useReducer(reduce, undefined, initialState);
+  const [state, dispatch] = useReducer(reduceWithHistory, undefined, initWithHistory);
   return (
     <div className="rc-stage">
       <PhoneFrame display={<NixieDisplay text={state.display} />}>
         <RotaryDial symbols={DIAL_SYMBOLS} onDial={dispatch} />
       </PhoneFrame>
+      <HistoryPanel entries={state.history} />
     </div>
   );
 }

--- a/src/components/rotary-calculator/RotaryCalculator.jsx
+++ b/src/components/rotary-calculator/RotaryCalculator.jsx
@@ -3,14 +3,16 @@ import { initialState, reduce } from '../../lib/calculator.mjs';
 import { DIAL_SYMBOLS } from './symbols.mjs';
 import NixieDisplay from './NixieDisplay.jsx';
 import RotaryDial from './RotaryDial.jsx';
+import PhoneFrame from './PhoneFrame.jsx';
 import './rotary-calculator.css';
 
 export default function RotaryCalculator() {
   const [state, dispatch] = useReducer(reduce, undefined, initialState);
   return (
     <div className="rc-stage">
-      <NixieDisplay text={state.display} />
-      <RotaryDial symbols={DIAL_SYMBOLS} onDial={dispatch} />
+      <PhoneFrame display={<NixieDisplay text={state.display} />}>
+        <RotaryDial symbols={DIAL_SYMBOLS} onDial={dispatch} />
+      </PhoneFrame>
     </div>
   );
 }

--- a/src/components/rotary-calculator/RotaryCalculator.jsx
+++ b/src/components/rotary-calculator/RotaryCalculator.jsx
@@ -1,41 +1,16 @@
-import { useReducer, useEffect } from 'react';
+import { useReducer } from 'react';
 import { initialState, reduce } from '../../lib/calculator.mjs';
 import { DIAL_SYMBOLS } from './symbols.mjs';
 import NixieDisplay from './NixieDisplay.jsx';
+import RotaryDial from './RotaryDial.jsx';
 import './rotary-calculator.css';
 
 export default function RotaryCalculator() {
   const [state, dispatch] = useReducer(reduce, undefined, initialState);
-
-  // Temporary: keyboard input so the engine is testable before the dial lands.
-  // Removed in Task 5 once the dial drives dispatch.
-  useEffect(() => {
-    const keyToken = (k) => {
-      if (k >= '0' && k <= '9') return k;
-      if (k === '.') return '.';
-      if (k === '+') return '+';
-      if (k === '-') return '-';
-      if (k === '*') return '×';
-      if (k === '/') return '÷';
-      if (k === 'Enter' || k === '=') return '=';
-      if (k === 'Escape' || k === 'c' || k === 'C') return 'C';
-      return null;
-    };
-    const onKey = (e) => {
-      const t = keyToken(e.key);
-      if (t) { e.preventDefault(); dispatch(t); }
-    };
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
-  }, []);
-
   return (
     <div className="rc-stage">
       <NixieDisplay text={state.display} />
-      {/* dial added in Task 5; symbols list ready: */}
-      <ul className="rc-symbol-preview">
-        {DIAL_SYMBOLS.map((s) => <li key={s.value}>{s.label}</li>)}
-      </ul>
+      <RotaryDial symbols={DIAL_SYMBOLS} onDial={dispatch} />
     </div>
   );
 }

--- a/src/components/rotary-calculator/RotaryCalculator.jsx
+++ b/src/components/rotary-calculator/RotaryCalculator.jsx
@@ -1,0 +1,9 @@
+import './rotary-calculator.css';
+
+export default function RotaryCalculator() {
+  return (
+    <div className="rc-stage">
+      <p>Rotary calculator coming soon.</p>
+    </div>
+  );
+}

--- a/src/components/rotary-calculator/RotaryCalculator.jsx
+++ b/src/components/rotary-calculator/RotaryCalculator.jsx
@@ -1,9 +1,41 @@
+import { useReducer, useEffect } from 'react';
+import { initialState, reduce } from '../../lib/calculator.mjs';
+import { DIAL_SYMBOLS } from './symbols.mjs';
+import NixieDisplay from './NixieDisplay.jsx';
 import './rotary-calculator.css';
 
 export default function RotaryCalculator() {
+  const [state, dispatch] = useReducer(reduce, undefined, initialState);
+
+  // Temporary: keyboard input so the engine is testable before the dial lands.
+  // Removed in Task 5 once the dial drives dispatch.
+  useEffect(() => {
+    const keyToken = (k) => {
+      if (k >= '0' && k <= '9') return k;
+      if (k === '.') return '.';
+      if (k === '+') return '+';
+      if (k === '-') return '-';
+      if (k === '*') return '×';
+      if (k === '/') return '÷';
+      if (k === 'Enter' || k === '=') return '=';
+      if (k === 'Escape' || k === 'c' || k === 'C') return 'C';
+      return null;
+    };
+    const onKey = (e) => {
+      const t = keyToken(e.key);
+      if (t) { e.preventDefault(); dispatch(t); }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, []);
+
   return (
     <div className="rc-stage">
-      <p>Rotary calculator coming soon.</p>
+      <NixieDisplay text={state.display} />
+      {/* dial added in Task 5; symbols list ready: */}
+      <ul className="rc-symbol-preview">
+        {DIAL_SYMBOLS.map((s) => <li key={s.value}>{s.label}</li>)}
+      </ul>
     </div>
   );
 }

--- a/src/components/rotary-calculator/RotaryDial.jsx
+++ b/src/components/rotary-calculator/RotaryDial.jsx
@@ -1,0 +1,80 @@
+import { useRef, useState } from 'react';
+import { holeLayout, pointerAngle, holeMaxRotation, rotationFor, reachedStop } from '../../lib/dial-geometry.mjs';
+
+const CX = 160, CY = 160, HOLE_R = 122, FINGER_STOP_DEG = 330;
+const LAYOUT_OPTS = { startDeg: 0, stepDeg: 18, radius: HOLE_R, cx: CX, cy: CY };
+
+export default function RotaryDial({ symbols, onDial }) {
+  const svgRef = useRef(null);
+  const drag = useRef(null);                 // { grabDeg, maxRot, value }
+  const [rotation, setRotation] = useState(0);
+  const [spinning, setSpinning] = useState(false);
+
+  const holes = holeLayout(symbols.map((s) => s.label), LAYOUT_OPTS);
+
+  const svgAngle = (e) => {
+    const rect = svgRef.current.getBoundingClientRect();
+    const scale = 320 / rect.width;
+    const px = (e.clientX - rect.left) * scale;
+    const py = (e.clientY - rect.top) * scale;
+    return pointerAngle(CX, CY, px, py);
+  };
+
+  const onPointerDown = (e, sym, angleDeg) => {
+    if (spinning) return;
+    e.currentTarget.setPointerCapture(e.pointerId);
+    drag.current = { grabDeg: angleDeg, maxRot: holeMaxRotation(angleDeg, FINGER_STOP_DEG), value: sym.value };
+    setRotation(0);
+  };
+
+  const onPointerMove = (e) => {
+    if (!drag.current) return;
+    const { grabDeg, maxRot } = drag.current;
+    setRotation(rotationFor(grabDeg, svgAngle(e), maxRot));
+  };
+
+  const onPointerUp = () => {
+    if (!drag.current) return;
+    const { maxRot, value } = drag.current;
+    const registered = reachedStop(rotation, maxRot);
+    drag.current = null;
+    if (rotation > 0) {                       // only animate (and arm onTransitionEnd) if we actually moved
+      setSpinning(true);                      // CSS transition animates rotation → 0
+      setRotation(0);
+    }
+    if (registered) onDial(value);
+  };
+
+  return (
+    <svg
+      ref={svgRef}
+      className="rc-dial"
+      viewBox="0 0 320 320"
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+      onPointerCancel={onPointerUp}
+    >
+      <circle cx={CX} cy={CY} r="150" className="rc-dial-face" />
+      <g
+        className={spinning ? 'rc-dial-rotor rc-spinning' : 'rc-dial-rotor'}
+        style={{ transform: `rotate(${rotation}deg)`, transformOrigin: `${CX}px ${CY}px` }}
+        onTransitionEnd={() => setSpinning(false)}
+      >
+        {holes.map((h, i) => (
+          <g
+            key={symbols[i].value}
+            className="rc-hole"
+            onPointerDown={(e) => onPointerDown(e, symbols[i], h.angleDeg)}
+          >
+            <circle cx={h.x} cy={h.y} r="20" className="rc-hole-bg" />
+            <text x={h.x} y={h.y} className="rc-hole-label" dominantBaseline="central" textAnchor="middle">
+              {h.symbol}
+            </text>
+          </g>
+        ))}
+      </g>
+      <circle cx={CX} cy={CY} r="46" className="rc-dial-hub" />
+      <rect x={CX + 96} y={CY + 70} width="26" height="16" rx="3" className="rc-finger-stop" />
+    </svg>
+  );
+}

--- a/src/components/rotary-calculator/RotaryDial.jsx
+++ b/src/components/rotary-calculator/RotaryDial.jsx
@@ -1,8 +1,9 @@
 import { useRef, useState } from 'react';
 import { holeLayout, pointerAngle, holeMaxRotation, rotationFor, reachedStop } from '../../lib/dial-geometry.mjs';
+import { DIAL_GEOMETRY } from './dial-config.mjs';
 
-const CX = 160, CY = 160, HOLE_R = 122, FINGER_STOP_DEG = 330;
-const LAYOUT_OPTS = { startDeg: 0, stepDeg: 18, radius: HOLE_R, cx: CX, cy: CY };
+const { cx: CX, cy: CY, holeRadius: HOLE_R, stopRadius: STOP_R, startDeg, stepDeg, fingerStopDeg: FINGER_STOP_DEG } = DIAL_GEOMETRY;
+const LAYOUT_OPTS = { startDeg, stepDeg, radius: HOLE_R, cx: CX, cy: CY };
 
 export default function RotaryDial({ symbols, onDial }) {
   const svgRef = useRef(null);
@@ -11,6 +12,7 @@ export default function RotaryDial({ symbols, onDial }) {
   const [spinning, setSpinning] = useState(false);
 
   const holes = holeLayout(symbols.map((s) => s.label), LAYOUT_OPTS);
+  const stop = holeLayout(['stop'], { startDeg: FINGER_STOP_DEG, stepDeg: 0, radius: STOP_R, cx: CX, cy: CY })[0];
 
   const svgAngle = (e) => {
     const rect = svgRef.current.getBoundingClientRect();
@@ -22,7 +24,7 @@ export default function RotaryDial({ symbols, onDial }) {
   const onPointerDown = (e, sym, angleDeg) => {
     if (spinning) return;
     e.currentTarget.setPointerCapture(e.pointerId);
-    drag.current = { grabDeg: angleDeg, maxRot: holeMaxRotation(angleDeg, FINGER_STOP_DEG), value: sym.value, lastRotation: 0 };
+    drag.current = { grabDeg: angleDeg, maxRot: holeMaxRotation(angleDeg, FINGER_STOP_DEG), value: sym.value, lastRotation: 0, peak: 0 };
     setRotation(0);
   };
 
@@ -31,15 +33,16 @@ export default function RotaryDial({ symbols, onDial }) {
     const { grabDeg, maxRot } = drag.current;
     const r = rotationFor(grabDeg, svgAngle(e), maxRot);
     drag.current.lastRotation = r;
+    if (r > drag.current.peak) drag.current.peak = r;
     setRotation(r);
   };
 
   const onPointerUp = () => {
     if (!drag.current) return;
-    const { maxRot, value, lastRotation } = drag.current;
-    const registered = reachedStop(lastRotation, maxRot);
+    const { maxRot, value, peak } = drag.current;
+    const registered = reachedStop(peak, maxRot);
     drag.current = null;
-    if (lastRotation > 0) {                   // only animate if we actually moved (else onTransitionEnd never fires)
+    if (peak > 0) {                           // only animate if we actually moved (else onTransitionEnd never fires)
       setSpinning(true);
       setRotation(0);
     }
@@ -75,7 +78,7 @@ export default function RotaryDial({ symbols, onDial }) {
         ))}
       </g>
       <circle cx={CX} cy={CY} r="46" className="rc-dial-hub" />
-      <rect x={CX + 96} y={CY + 70} width="26" height="16" rx="3" className="rc-finger-stop" />
+      <circle cx={stop.x} cy={stop.y} r="11" className="rc-finger-stop" />
     </svg>
   );
 }

--- a/src/components/rotary-calculator/RotaryDial.jsx
+++ b/src/components/rotary-calculator/RotaryDial.jsx
@@ -1,15 +1,19 @@
-import { useRef, useState } from 'react';
+import { useRef, useState, useEffect } from 'react';
 import { holeLayout, pointerAngle, holeMaxRotation, rotationFor, reachedStop } from '../../lib/dial-geometry.mjs';
 import { DIAL_GEOMETRY } from './dial-config.mjs';
 
 const { cx: CX, cy: CY, holeRadius: HOLE_R, stopRadius: STOP_R, startDeg, stepDeg, fingerStopDeg: FINGER_STOP_DEG } = DIAL_GEOMETRY;
 const LAYOUT_OPTS = { startDeg, stepDeg, radius: HOLE_R, cx: CX, cy: CY };
+const SPIN_MS = 500;                          // keep in sync with the CSS transition
 
 export default function RotaryDial({ symbols, onDial }) {
   const svgRef = useRef(null);
-  const drag = useRef(null);                 // { grabDeg, maxRot, value, lastRotation }
+  const drag = useRef(null);                 // { grabDeg, maxRot, value, lastRotation, peak }
+  const spinTimer = useRef(null);            // fallback that always clears `spinning`
   const [rotation, setRotation] = useState(0);
   const [spinning, setSpinning] = useState(false);
+
+  useEffect(() => () => clearTimeout(spinTimer.current), []);
 
   const holes = holeLayout(symbols.map((s) => s.label), LAYOUT_OPTS);
   const stop = holeLayout(['stop'], { startDeg: FINGER_STOP_DEG, stepDeg: 0, radius: STOP_R, cx: CX, cy: CY })[0];
@@ -22,7 +26,10 @@ export default function RotaryDial({ symbols, onDial }) {
   };
 
   const onPointerDown = (e, sym, angleDeg) => {
-    if (spinning) return;
+    // Always responsive: a new grab cancels any in-progress spin-back so the
+    // dial can never get stuck waiting on a transition that didn't fire.
+    clearTimeout(spinTimer.current);
+    setSpinning(false);
     e.currentTarget.setPointerCapture(e.pointerId);
     drag.current = { grabDeg: angleDeg, maxRot: holeMaxRotation(angleDeg, FINGER_STOP_DEG), value: sym.value, lastRotation: 0, peak: 0 };
     setRotation(0);
@@ -42,9 +49,11 @@ export default function RotaryDial({ symbols, onDial }) {
     const { maxRot, value, peak } = drag.current;
     const registered = reachedStop(peak, maxRot);
     drag.current = null;
-    if (peak > 0) {                           // only animate if we actually moved (else onTransitionEnd never fires)
+    if (peak > 0) {                           // animate the spin-back from where we are
       setSpinning(true);
       setRotation(0);
+      clearTimeout(spinTimer.current);        // fallback in case onTransitionEnd never fires
+      spinTimer.current = setTimeout(() => setSpinning(false), SPIN_MS + 50);
     }
     if (registered) onDial(value);
   };
@@ -62,7 +71,7 @@ export default function RotaryDial({ symbols, onDial }) {
       <g
         className={spinning ? 'rc-dial-rotor rc-spinning' : 'rc-dial-rotor'}
         style={{ transform: `rotate(${rotation}deg)`, transformOrigin: `${CX}px ${CY}px` }}
-        onTransitionEnd={(e) => { if (e.target === e.currentTarget) setSpinning(false); }}
+        onTransitionEnd={(e) => { if (e.target === e.currentTarget) { clearTimeout(spinTimer.current); setSpinning(false); } }}
       >
         {holes.map((h, i) => (
           <g

--- a/src/components/rotary-calculator/RotaryDial.jsx
+++ b/src/components/rotary-calculator/RotaryDial.jsx
@@ -6,7 +6,7 @@ const LAYOUT_OPTS = { startDeg: 0, stepDeg: 18, radius: HOLE_R, cx: CX, cy: CY }
 
 export default function RotaryDial({ symbols, onDial }) {
   const svgRef = useRef(null);
-  const drag = useRef(null);                 // { grabDeg, maxRot, value }
+  const drag = useRef(null);                 // { grabDeg, maxRot, value, lastRotation }
   const [rotation, setRotation] = useState(0);
   const [spinning, setSpinning] = useState(false);
 
@@ -14,32 +14,33 @@ export default function RotaryDial({ symbols, onDial }) {
 
   const svgAngle = (e) => {
     const rect = svgRef.current.getBoundingClientRect();
-    const scale = 320 / rect.width;
-    const px = (e.clientX - rect.left) * scale;
-    const py = (e.clientY - rect.top) * scale;
+    const px = (e.clientX - rect.left) * (320 / rect.width);
+    const py = (e.clientY - rect.top) * (320 / rect.height);
     return pointerAngle(CX, CY, px, py);
   };
 
   const onPointerDown = (e, sym, angleDeg) => {
     if (spinning) return;
     e.currentTarget.setPointerCapture(e.pointerId);
-    drag.current = { grabDeg: angleDeg, maxRot: holeMaxRotation(angleDeg, FINGER_STOP_DEG), value: sym.value };
+    drag.current = { grabDeg: angleDeg, maxRot: holeMaxRotation(angleDeg, FINGER_STOP_DEG), value: sym.value, lastRotation: 0 };
     setRotation(0);
   };
 
   const onPointerMove = (e) => {
     if (!drag.current) return;
     const { grabDeg, maxRot } = drag.current;
-    setRotation(rotationFor(grabDeg, svgAngle(e), maxRot));
+    const r = rotationFor(grabDeg, svgAngle(e), maxRot);
+    drag.current.lastRotation = r;
+    setRotation(r);
   };
 
   const onPointerUp = () => {
     if (!drag.current) return;
-    const { maxRot, value } = drag.current;
-    const registered = reachedStop(rotation, maxRot);
+    const { maxRot, value, lastRotation } = drag.current;
+    const registered = reachedStop(lastRotation, maxRot);
     drag.current = null;
-    if (rotation > 0) {                       // only animate (and arm onTransitionEnd) if we actually moved
-      setSpinning(true);                      // CSS transition animates rotation → 0
+    if (lastRotation > 0) {                   // only animate if we actually moved (else onTransitionEnd never fires)
+      setSpinning(true);
       setRotation(0);
     }
     if (registered) onDial(value);
@@ -58,7 +59,7 @@ export default function RotaryDial({ symbols, onDial }) {
       <g
         className={spinning ? 'rc-dial-rotor rc-spinning' : 'rc-dial-rotor'}
         style={{ transform: `rotate(${rotation}deg)`, transformOrigin: `${CX}px ${CY}px` }}
-        onTransitionEnd={() => setSpinning(false)}
+        onTransitionEnd={(e) => { if (e.target === e.currentTarget) setSpinning(false); }}
       >
         {holes.map((h, i) => (
           <g

--- a/src/components/rotary-calculator/dial-config.mjs
+++ b/src/components/rotary-calculator/dial-config.mjs
@@ -1,0 +1,13 @@
+// Dial layout geometry, shared by RotaryDial and its invariant test.
+// Holes are laid out AWAY from the finger stop (negative step) so the first
+// symbol ('1') is the shortest dial and every hole's max rotation stays well
+// under the 330° counterclockwise-jitter boundary in rotationFor.
+export const DIAL_GEOMETRY = {
+  cx: 160,
+  cy: 160,
+  holeRadius: 122,
+  stopRadius: 138,
+  startDeg: 117,     // '1' sits just counterclockwise of the finger stop
+  stepDeg: -18,      // later symbols fan out counterclockwise
+  fingerStopDeg: 135,
+};

--- a/src/components/rotary-calculator/rotary-calculator.css
+++ b/src/components/rotary-calculator/rotary-calculator.css
@@ -1,10 +1,12 @@
 .rc-stage {
   display: flex;
+  flex-wrap: wrap;
+  flex-direction: row;
   justify-content: center;
+  align-items: flex-start;
+  gap: 1.5rem;
   padding: 1.5rem 0;
 }
-
-.rc-stage { flex-direction: column; align-items: center; gap: 1rem; }
 
 .rc-nixie {
   background: #000;
@@ -36,16 +38,14 @@
 .rc-finger-stop { fill: #c0392b; }
 
 .rc-phone { display: flex; flex-direction: column; align-items: center; }
-.rc-handset {
-  display: flex; align-items: center; width: 19rem; max-width: 88vw; height: 2.6rem;
-  margin-bottom: -0.8rem; z-index: 2;
+.rc-handset { width: 17rem; max-width: 84vw; display: block; margin-bottom: -0.6rem; }
+.rc-handset-handle {
+  fill: none; stroke: #1a1a1f; stroke-width: 24; stroke-linecap: round;
 }
-.rc-earpiece {
-  width: 3.2rem; height: 2.6rem; border-radius: 1.3rem / 1.1rem;
-  background: linear-gradient(160deg, #2a2a30, #0c0c10);
-  border: 1px solid #3a3a42;
+.rc-handset-bulb {
+  fill: #1a1a1f; stroke: #3a3a42; stroke-width: 2;
 }
-.rc-handle { flex: 1; height: 1.2rem; background: #0e0e12; border: 1px solid #3a3a42; border-radius: 0.6rem; }
+.rc-cradle { fill: #0c0c10; stroke: #3a3a42; stroke-width: 1.5; }
 .rc-body {
   background: radial-gradient(circle at 40% 25%, #26262c, #111114);
   border: 2px solid #3a3a42; border-radius: 1.5rem 1.5rem 2rem 2rem;
@@ -54,3 +54,26 @@
 }
 .rc-display-strip { width: 100%; display: flex; justify-content: center; }
 .rc-dial-mount { display: flex; justify-content: center; }
+
+/* History log */
+.rc-history {
+  width: 15rem; max-width: 90vw;
+  background: #0c0b0a; border: 1px solid #2a2118; border-radius: 8px;
+  padding: 0.75rem 1rem; max-height: 30rem; overflow-y: auto;
+}
+.rc-history-title {
+  margin: 0 0 0.5rem; font-size: 0.8rem; letter-spacing: 0.25em;
+  text-transform: uppercase; color: #b5703a; font-weight: bold;
+}
+.rc-history-empty { margin: 0; color: #7a5a3a; font-size: 0.85rem; }
+.rc-history-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.45rem; }
+.rc-history-item {
+  display: flex; flex-wrap: wrap; align-items: baseline; gap: 0.35rem;
+  font-family: 'Courier New', monospace; font-size: 0.95rem;
+  padding-bottom: 0.4rem; border-bottom: 1px dashed #2a2118;
+}
+.rc-history-expr { color: #c98a4a; word-break: break-all; }
+.rc-history-eq { color: #7a5a3a; }
+.rc-history-result {
+  margin-left: auto; color: #ff9a3c; font-weight: bold; text-shadow: 0 0 5px #ff7a00;
+}

--- a/src/components/rotary-calculator/rotary-calculator.css
+++ b/src/components/rotary-calculator/rotary-calculator.css
@@ -3,3 +3,22 @@
   justify-content: center;
   padding: 1.5rem 0;
 }
+
+.rc-stage { flex-direction: column; align-items: center; gap: 1rem; }
+
+.rc-nixie {
+  background: #000;
+  border: 1px solid #2a2118;
+  border-radius: 6px;
+  padding: 0.5rem 1rem;
+  min-width: 14rem;
+  text-align: right;
+}
+.rc-nixie-text {
+  font-family: 'Courier New', monospace;
+  font-size: 2rem;
+  letter-spacing: 0.15em;
+  color: #ff9a3c;
+  text-shadow: 0 0 6px #ff7a00, 0 0 16px #ff5500;
+}
+.rc-symbol-preview { display: none; } /* preview only; dial replaces it in Task 5 */

--- a/src/components/rotary-calculator/rotary-calculator.css
+++ b/src/components/rotary-calculator/rotary-calculator.css
@@ -1,0 +1,5 @@
+.rc-stage {
+  display: flex;
+  justify-content: center;
+  padding: 1.5rem 0;
+}

--- a/src/components/rotary-calculator/rotary-calculator.css
+++ b/src/components/rotary-calculator/rotary-calculator.css
@@ -34,3 +34,23 @@
   text-shadow: 0 0 4px #ff7a00; pointer-events: none;
 }
 .rc-finger-stop { fill: #c0392b; }
+
+.rc-phone { display: flex; flex-direction: column; align-items: center; }
+.rc-handset {
+  display: flex; align-items: center; width: 19rem; max-width: 88vw; height: 2.6rem;
+  margin-bottom: -0.8rem; z-index: 2;
+}
+.rc-earpiece {
+  width: 3.2rem; height: 2.6rem; border-radius: 1.3rem / 1.1rem;
+  background: linear-gradient(160deg, #2a2a30, #0c0c10);
+  border: 1px solid #3a3a42;
+}
+.rc-handle { flex: 1; height: 1.2rem; background: #0e0e12; border: 1px solid #3a3a42; border-radius: 0.6rem; }
+.rc-body {
+  background: radial-gradient(circle at 40% 25%, #26262c, #111114);
+  border: 2px solid #3a3a42; border-radius: 1.5rem 1.5rem 2rem 2rem;
+  padding: 1.6rem 1.4rem 2rem; display: flex; flex-direction: column;
+  align-items: center; gap: 1.1rem; box-shadow: 0 10px 28px rgba(0,0,0,.5);
+}
+.rc-display-strip { width: 100%; display: flex; justify-content: center; }
+.rc-dial-mount { display: flex; justify-content: center; }

--- a/src/components/rotary-calculator/rotary-calculator.css
+++ b/src/components/rotary-calculator/rotary-calculator.css
@@ -22,3 +22,15 @@
   text-shadow: 0 0 6px #ff7a00, 0 0 16px #ff5500;
 }
 .rc-symbol-preview { display: none; } /* preview only; dial replaces it in Task 5 */
+
+.rc-dial { width: 320px; max-width: 90vw; touch-action: none; user-select: none; }
+.rc-dial-face { fill: #1c1c22; stroke: #2a2a33; stroke-width: 2; }
+.rc-dial-hub { fill: #0e0e12; }
+.rc-dial-rotor.rc-spinning { transition: transform 0.5s cubic-bezier(0.4, 1.4, 0.6, 1); }
+.rc-hole { cursor: grab; }
+.rc-hole-bg { fill: #000; stroke: #ff9a3c; stroke-width: 1; }
+.rc-hole-label {
+  fill: #ff9a3c; font-family: Georgia, serif; font-size: 18px;
+  text-shadow: 0 0 4px #ff7a00; pointer-events: none;
+}
+.rc-finger-stop { fill: #c0392b; }

--- a/src/components/rotary-calculator/symbols.mjs
+++ b/src/components/rotary-calculator/symbols.mjs
@@ -1,0 +1,11 @@
+// The 17 symbols on the dial, in clockwise order. `label` is the glyph shown;
+// `value` is the token fed to the calculator engine.
+export const DIAL_SYMBOLS = [
+  { label: '1', value: '1' }, { label: '2', value: '2' }, { label: '3', value: '3' },
+  { label: '4', value: '4' }, { label: '5', value: '5' }, { label: '6', value: '6' },
+  { label: '7', value: '7' }, { label: '8', value: '8' }, { label: '9', value: '9' },
+  { label: '0', value: '0' }, { label: '.', value: '.' },
+  { label: '+', value: '+' }, { label: '−', value: '-' },
+  { label: '×', value: '×' }, { label: '÷', value: '÷' },
+  { label: '=', value: '=' }, { label: 'C', value: 'C' },
+];

--- a/src/lib/calculator-history.mjs
+++ b/src/lib/calculator-history.mjs
@@ -1,0 +1,22 @@
+// Wraps the pure calculator engine with a running history log. Each successful
+// '=' appends { id, expr, result } (newest first). No DOM, no React.
+import { initialState, reduce } from './calculator.mjs';
+
+const MAX_ENTRIES = 50;
+
+export function initWithHistory() {
+  return { ...initialState(), history: [], nextId: 1 };
+}
+
+export function reduceWithHistory(state, token) {
+  const next = reduce(state, token);
+  const records =
+    token === '=' && next.justEvaluated && !next.error && next.display !== state.display;
+  if (records) {
+    const id = state.nextId;
+    const entry = { id, expr: state.display, result: next.display };
+    return { ...next, history: [entry, ...state.history].slice(0, MAX_ENTRIES), nextId: id + 1 };
+  }
+  // Carry the log across every other token (digits, operators, C all keep it).
+  return { ...next, history: state.history, nextId: state.nextId };
+}

--- a/src/lib/calculator.mjs
+++ b/src/lib/calculator.mjs
@@ -1,0 +1,114 @@
+// Pure 4-function calculator engine. No DOM, no React.
+// Builds an expression of tokens and evaluates only on '='. × ÷ bind before + −.
+
+const OPERATORS = new Set(['+', '-', '×', '÷']);
+
+export function initialState() {
+  return {
+    tokens: [],        // committed expression: [number, op, number, op, ...]
+    entry: '',         // number currently being typed
+    display: '0',
+    justEvaluated: false,
+    error: false,
+    lastResult: 0,
+  };
+}
+
+function exprString(tokens, entry) {
+  const s = tokens.map(String).join('') + entry;
+  return s === '' ? '0' : s;
+}
+
+function appendDigit(entry, d) {
+  if (entry === '0') return d === '0' ? '0' : d;
+  return entry + d;
+}
+
+// Evaluate [num, op, num, op, ...] with precedence. Throws on divide-by-zero.
+function evalExpression(tokens) {
+  const pass1 = [tokens[0]];
+  for (let i = 1; i < tokens.length; i += 2) {
+    const op = tokens[i];
+    const num = tokens[i + 1];
+    if (op === '×') {
+      pass1[pass1.length - 1] *= num;
+    } else if (op === '÷') {
+      if (num === 0) throw new Error('divide by zero');
+      pass1[pass1.length - 1] /= num;
+    } else {
+      pass1.push(op, num);
+    }
+  }
+  let acc = pass1[0];
+  for (let i = 1; i < pass1.length; i += 2) {
+    acc = pass1[i] === '+' ? acc + pass1[i + 1] : acc - pass1[i + 1];
+  }
+  return acc;
+}
+
+function formatResult(n) {
+  if (!Number.isFinite(n)) return 'Error';
+  const rounded = Number(n.toPrecision(12));
+  let s = String(rounded);
+  if (s.replace(/[-.]/g, '').length > 12) s = rounded.toExponential(6);
+  return s;
+}
+
+function inputDigit(state, d) {
+  const base = state.error || state.justEvaluated ? initialState() : state;
+  const entry = appendDigit(base.entry, d);
+  return { ...base, entry, justEvaluated: false, display: exprString(base.tokens, entry) };
+}
+
+function inputDot(state) {
+  const base = state.error || state.justEvaluated ? initialState() : state;
+  let entry = base.entry;
+  if (entry === '') entry = '0.';
+  else if (entry.includes('.')) entry = entry; // ignore second dot
+  else entry = entry + '.';
+  return { ...base, entry, justEvaluated: false, display: exprString(base.tokens, entry) };
+}
+
+function inputOperator(state, op) {
+  if (state.error) return state;
+  let tokens;
+  let entry = '';
+  if (state.justEvaluated) {
+    tokens = [state.lastResult];
+  } else {
+    tokens = state.tokens.slice();
+  }
+  if (state.entry !== '' && !state.justEvaluated) {
+    tokens.push(Number(state.entry));
+  }
+  const last = tokens[tokens.length - 1];
+  if (tokens.length === 0) return state;            // nothing to operate on
+  if (typeof last === 'string') tokens[tokens.length - 1] = op; // replace operator
+  else tokens.push(op);
+  return { ...state, tokens, entry, justEvaluated: false, error: false, display: exprString(tokens, '') };
+}
+
+function evaluate(state) {
+  if (state.error) return state;
+  const tokens = state.tokens.slice();
+  if (state.entry !== '') tokens.push(Number(state.entry));
+  if (typeof tokens[tokens.length - 1] === 'string') tokens.pop(); // drop trailing operator
+  if (tokens.length === 0) return state;
+  let result;
+  try {
+    result = evalExpression(tokens);
+  } catch {
+    return { ...initialState(), error: true, display: 'Error' };
+  }
+  if (!Number.isFinite(result)) return { ...initialState(), error: true, display: 'Error' };
+  return { ...initialState(), display: formatResult(result), lastResult: result, justEvaluated: true };
+}
+
+export function reduce(state, token) {
+  if (token === 'C') return initialState();
+  if (token === '=') return evaluate(state);
+  if (token === '.') return inputDot(state);
+  if (OPERATORS.has(token)) return inputOperator(state, token);
+  if (token >= '0' && token <= '9') return inputDigit(state, token);
+  return state; // unknown token ignored
+}

--- a/src/lib/dial-geometry.mjs
+++ b/src/lib/dial-geometry.mjs
@@ -26,8 +26,8 @@ export function holeMaxRotation(holeAngleDeg, fingerStopDeg) {
 export function rotationFor(grabDeg, pointerDeg, maxRot, slack = 30) {
   const delta = (pointerDeg - grabDeg + 360) % 360;
   if (delta <= maxRot) return delta;
-  if (delta >= 360 - slack) return 0; // counterclockwise jitter
-  return maxRot;                       // dragged past the stop
+  if (maxRot < 360 - slack && delta >= 360 - slack) return 0; // CCW jitter only when windows don't overlap
+  return maxRot;                                              // dragged past the stop
 }
 
 export function reachedStop(rotation, maxRot, threshold = 0.9) {

--- a/src/lib/dial-geometry.mjs
+++ b/src/lib/dial-geometry.mjs
@@ -1,0 +1,35 @@
+// Pure dial geometry. Angles are degrees clockwise from 12 o'clock.
+
+export function holeLayout(symbols, { startDeg = 0, stepDeg = 18, radius = 1, cx = 0, cy = 0 } = {}) {
+  return symbols.map((symbol, i) => {
+    const angleDeg = startDeg + i * stepDeg;
+    const rad = (angleDeg * Math.PI) / 180;
+    return {
+      symbol,
+      angleDeg,
+      x: cx + radius * Math.sin(rad),
+      y: cy - radius * Math.cos(rad),
+    };
+  });
+}
+
+export function pointerAngle(cx, cy, px, py) {
+  let deg = (Math.atan2(px - cx, -(py - cy)) * 180) / Math.PI;
+  if (deg < 0) deg += 360;
+  return deg;
+}
+
+export function holeMaxRotation(holeAngleDeg, fingerStopDeg) {
+  return (fingerStopDeg - holeAngleDeg + 360) % 360;
+}
+
+export function rotationFor(grabDeg, pointerDeg, maxRot, slack = 30) {
+  const delta = (pointerDeg - grabDeg + 360) % 360;
+  if (delta <= maxRot) return delta;
+  if (delta >= 360 - slack) return 0; // counterclockwise jitter
+  return maxRot;                       // dragged past the stop
+}
+
+export function reachedStop(rotation, maxRot, threshold = 0.9) {
+  return rotation >= maxRot * threshold;
+}

--- a/src/pages/rotary-calculator.astro
+++ b/src/pages/rotary-calculator.astro
@@ -1,0 +1,8 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import RotaryCalculator from '../components/rotary-calculator/RotaryCalculator.jsx';
+---
+<BaseLayout title="轉盤計算機">
+  <h1 class="text-2xl font-bold mb-6">轉盤計算機</h1>
+  <RotaryCalculator client:load />
+</BaseLayout>

--- a/src/pages/tools.astro
+++ b/src/pages/tools.astro
@@ -6,6 +6,7 @@ const tools = [
   { icon: '⏱', title: '拉密計時', href: '/rummikub-timer/', desc: '桌遊回合計時器', external: false },
   { icon: '🅿️', title: '車位抽籤', href: '/lottery/', desc: '可重現的公正抽籤', external: false },
   { icon: '🧭', title: 'MBTI · 認識你自己', href: '/mbti96/', desc: '96 題性格測驗', external: false },
+  { icon: '☎️', title: '轉盤計算機', href: '/rotary-calculator/', desc: '用古董轉盤電話打數字的計算機', external: false },
   { icon: '🌿', title: 'GitCrisp', href: 'https://blog.aidan.tw/GitCrisp/', desc: '個人實作的 Git GUI', external: true },
   { icon: '🧱', title: 'block6', href: 'https://block6.aidan.tw/', desc: '個人使用的生產力工具', external: true },
 ];

--- a/test/calculator-history.test.mjs
+++ b/test/calculator-history.test.mjs
@@ -1,0 +1,41 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { initWithHistory, reduceWithHistory } from '../src/lib/calculator-history.mjs';
+
+const run = (tokens) => tokens.reduce(reduceWithHistory, initWithHistory());
+
+test('history starts empty', () => {
+  assert.deepEqual(initWithHistory().history, []);
+});
+
+test('= records the evaluated expression and its result', () => {
+  const s = run(['2', '+', '3', '×', '4', '=']);
+  assert.equal(s.history.length, 1);
+  assert.equal(s.history[0].expr, '2+3×4');
+  assert.equal(s.history[0].result, '14');
+});
+
+test('results accumulate newest-first with unique ids', () => {
+  const s = run(['1', '+', '1', '=', '2', '×', '3', '=']);
+  assert.equal(s.history.length, 2);
+  assert.equal(s.history[0].expr, '2×3');
+  assert.equal(s.history[0].result, '6');
+  assert.equal(s.history[1].result, '2');
+  assert.notEqual(s.history[0].id, s.history[1].id);
+});
+
+test('errors are not recorded', () => {
+  const s = run(['5', '÷', '0', '=']);
+  assert.equal(s.history.length, 0);
+});
+
+test('pressing = with nothing to compute records nothing; repeated = does not double-record', () => {
+  assert.equal(run(['=']).history.length, 0);
+  assert.equal(run(['2', '+', '3', '=', '=']).history.length, 1); // second = is a no-op
+});
+
+test('C clears the current entry but keeps the history log', () => {
+  const s = run(['1', '+', '1', '=', 'C']);
+  assert.equal(s.history.length, 1);
+  assert.equal(s.display, '0');
+});

--- a/test/calculator.test.mjs
+++ b/test/calculator.test.mjs
@@ -1,0 +1,90 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { initialState, reduce } from '../src/lib/calculator.mjs';
+
+// Feed a sequence of tokens through reduce, return final state.
+function run(tokens) {
+  return tokens.reduce(reduce, initialState());
+}
+const display = (tokens) => run(tokens).display;
+
+test('initial display is 0', () => {
+  assert.equal(initialState().display, '0');
+});
+
+test('typing digits builds the entry', () => {
+  assert.equal(display(['1', '2', '3']), '123');
+});
+
+test('leading zero is replaced by the next digit', () => {
+  assert.equal(display(['0', '5']), '5');
+  assert.equal(display(['0', '0']), '0');
+});
+
+test('decimal point is added once; a second dot is ignored', () => {
+  assert.equal(display(['1', '.', '5']), '1.5');
+  assert.equal(display(['1', '.', '5', '.', '2']), '1.52');
+});
+
+test('a leading dot becomes 0.', () => {
+  assert.equal(display(['.', '5']), '0.5');
+});
+
+test('expression string grows as operators are added', () => {
+  assert.equal(display(['2', '+', '3', '×', '4']), '2+3×4');
+});
+
+test('nothing is computed until = is pressed', () => {
+  // before '=' the display is still the expression, not 5
+  assert.equal(display(['2', '+', '3']), '2+3');
+});
+
+test('= evaluates with precedence: 2+3×4 = 14', () => {
+  assert.equal(display(['2', '+', '3', '×', '4', '=']), '14');
+});
+
+test('= respects left-to-right within a level: 8÷4÷2 = 1', () => {
+  assert.equal(display(['8', '÷', '4', '÷', '2', '=']), '1');
+});
+
+test('subtraction and addition: 10-3+1 = 8', () => {
+  assert.equal(display(['1', '0', '-', '3', '+', '1', '=']), '8');
+});
+
+test('a second operator replaces the pending one', () => {
+  assert.equal(display(['5', '+', '-', '2', '=']), '3');
+});
+
+test('after =, a digit starts a fresh expression', () => {
+  const s = run(['2', '+', '3', '=']);      // display 5
+  const s2 = reduce(s, '7');
+  assert.equal(s2.display, '7');
+});
+
+test('after =, an operator continues from the result', () => {
+  const s = run(['2', '+', '3', '=']);      // 5
+  const s2 = ['×', '4', '='].reduce(reduce, s);
+  assert.equal(s2.display, '20');
+});
+
+test('divide by zero shows Error', () => {
+  assert.equal(display(['5', '÷', '0', '=']), 'Error');
+});
+
+test('Error is cleared by starting a new number', () => {
+  const s = run(['5', '÷', '0', '=']);      // Error
+  const s2 = reduce(s, '9');
+  assert.equal(s2.display, '9');
+});
+
+test('C resets everything', () => {
+  assert.equal(display(['1', '2', '+', '3', 'C']), '0');
+});
+
+test('trailing operator before = is ignored: 2+ = 2', () => {
+  assert.equal(display(['2', '+', '=']), '2');
+});
+
+test('float noise is rounded: 0.1+0.2 = 0.3', () => {
+  assert.equal(display(['0', '.', '1', '+', '0', '.', '2', '=']), '0.3');
+});

--- a/test/dial-config.test.mjs
+++ b/test/dial-config.test.mjs
@@ -1,0 +1,24 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { holeLayout, holeMaxRotation, reachedStop } from '../src/lib/dial-geometry.mjs';
+import { DIAL_GEOMETRY } from '../src/components/rotary-calculator/dial-config.mjs';
+import { DIAL_SYMBOLS } from '../src/components/rotary-calculator/symbols.mjs';
+
+const { startDeg, stepDeg, holeRadius, cx, cy, fingerStopDeg } = DIAL_GEOMETRY;
+
+test('all 17 dial symbols are registerable and clear of the jitter boundary', () => {
+  const holes = holeLayout(DIAL_SYMBOLS.map((s) => s.label), { startDeg, stepDeg, radius: holeRadius, cx, cy });
+  assert.equal(holes.length, 17);
+  for (const h of holes) {
+    const maxRot = holeMaxRotation(h.angleDeg, fingerStopDeg);
+    assert.ok(maxRot > 0, `${h.symbol}: maxRot ${maxRot} must be > 0`);
+    assert.ok(maxRot < 330, `${h.symbol}: maxRot ${maxRot} must be < 330 (jitter-guard boundary)`);
+    assert.ok(reachedStop(maxRot, maxRot), `${h.symbol}: must register when dragged to its stop`);
+  }
+});
+
+test('the first symbol (1) is the shortest dial', () => {
+  const holes = holeLayout(DIAL_SYMBOLS.map((s) => s.label), { startDeg, stepDeg, radius: holeRadius, cx, cy });
+  const maxRots = holes.map((h) => holeMaxRotation(h.angleDeg, fingerStopDeg));
+  assert.equal(Math.min(...maxRots), maxRots[0]);
+});

--- a/test/dial-geometry.test.mjs
+++ b/test/dial-geometry.test.mjs
@@ -39,6 +39,15 @@ test('rotationFor treats counterclockwise jitter as 0', () => {
   assert.equal(rotationFor(0, 340, 300), 0);
 });
 
+test('rotationFor pins a past-stop drag even when maxRot is large', () => {
+  // maxRot=335 (> 360-slack=330): delta=340 is past the stop, must pin to 335, not 0
+  assert.equal(rotationFor(0, 340, 335), 335);
+});
+
+test('rotationFor still treats CCW jitter as 0 for normal-sized maxRot', () => {
+  assert.equal(rotationFor(0, 355, 300), 0);
+});
+
 test('reachedStop is true only near the max rotation', () => {
   assert.equal(reachedStop(300, 300), true);
   assert.equal(reachedStop(100, 300), false);

--- a/test/dial-geometry.test.mjs
+++ b/test/dial-geometry.test.mjs
@@ -1,0 +1,45 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  holeLayout, pointerAngle, holeMaxRotation, rotationFor, reachedStop,
+} from '../src/lib/dial-geometry.mjs';
+
+const close = (a, b, eps = 1e-9) => assert.ok(Math.abs(a - b) < eps, `${a} ≈ ${b}`);
+
+test('holeLayout places symbols at evenly spaced clockwise angles', () => {
+  const holes = holeLayout(['a', 'b', 'c', 'd'], { startDeg: 0, stepDeg: 90, radius: 1 });
+  assert.equal(holes.length, 4);
+  assert.deepEqual(holes.map((h) => h.angleDeg), [0, 90, 180, 270]);
+  close(holes[0].x, 0); close(holes[0].y, -1);   // top
+  close(holes[1].x, 1); close(holes[1].y, 0);    // right
+});
+
+test('pointerAngle measures clockwise from the top', () => {
+  close(pointerAngle(0, 0, 0, -1), 0);    // up = 0
+  close(pointerAngle(0, 0, 1, 0), 90);    // right = 90
+  close(pointerAngle(0, 0, 0, 1), 180);   // down = 180
+  close(pointerAngle(0, 0, -1, 0), 270);  // left = 270
+});
+
+test('holeMaxRotation is the clockwise distance to the finger stop', () => {
+  assert.equal(holeMaxRotation(0, 315), 315);
+  assert.equal(holeMaxRotation(288, 315), 27);
+});
+
+test('rotationFor clamps a clockwise drag between 0 and the max', () => {
+  assert.equal(rotationFor(0, 45, 300), 45);
+  assert.equal(rotationFor(0, 300, 300), 300);
+});
+
+test('rotationFor pins past-the-stop drags to the max', () => {
+  assert.equal(rotationFor(0, 310, 300), 300);
+});
+
+test('rotationFor treats counterclockwise jitter as 0', () => {
+  assert.equal(rotationFor(0, 340, 300), 0);
+});
+
+test('reachedStop is true only near the max rotation', () => {
+  assert.equal(reachedStop(300, 300), true);
+  assert.equal(reachedStop(100, 300), false);
+});


### PR DESCRIPTION
## Summary
- New `/rotary-calculator/` tool: a vintage desk **telephone** whose single 17-symbol rotary dial drives a 4-function calculator. Drag a hole clockwise to the finger-stop and release — the dial spins back and the symbol registers on return. Dark retro-tech body with a glowing **nixie** display strip above the dial.
- Expression engine evaluates **only on `=`** with operator **precedence** (`2 + 3 × 4 =` → `14`), decimals, and divide-by-zero → `Error`.
- Site's first **React island** (`@astrojs/react`, `client:load`); added to the Tools hub.

## Architecture
- `src/lib/calculator.mjs` — pure expression engine (precedence, eval on `=`), unit-tested.
- `src/lib/dial-geometry.mjs` + `src/components/rotary-calculator/dial-config.mjs` — pure dial math + layout, unit-tested with a layout invariant (every symbol registerable, clear of the jitter boundary).
- `src/components/rotary-calculator/` — `RotaryDial` (drag + spin-back), `NixieDisplay`, `PhoneFrame` (telephone chrome), `RotaryCalculator` (container).
- Page `src/pages/rotary-calculator.astro`; hub entry in `src/pages/tools.astro`.
- Spec: `docs/superpowers/specs/2026-06-14-rotary-calculator-design.md`; plan: `docs/superpowers/plans/2026-06-14-rotary-calculator.md`.

## Test Plan
- [x] `npm test` — 38 unit tests pass (calculator engine, dial geometry, layout invariant).
- [x] `npm run build` — succeeds; `/rotary-calculator/` emitted.
- [ ] Manual: drag a hole to the finger-stop → spins back, registers on return; short drags register nothing; input ignored while spinning; `2 + 3 × 4 =` → 14; `5 ÷ 0 =` → Error; `C` resets; Tools hub shows the ☎️ card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)